### PR TITLE
申請フォームの整数入力をプルダウン（ドロップダウン）に変更 #335

### DIFF
--- a/resources/js/forms_editor/components/form/QuestionNumber.vue
+++ b/resources/js/forms_editor/components/form/QuestionNumber.vue
@@ -11,16 +11,19 @@
         </p>
         <template v-if="numberOptions.length > 0">
           <select class="custom-select" tabindex="-1">
-            <option>整数入力</option>
+            <option>整数を選択</option>
             <option v-for="n in numberOptions" :key="n" :value="n">
               {{ n }}
             </option>
           </select>
         </template>
         <template v-else>
-          <select class="custom-select" tabindex="-1" disabled>
-            <option>最低数・最大数を設定してください</option>
-          </select>
+          <input
+            type="number"
+            class="form-control"
+            tabindex="-1"
+            placeholder="整数入力（最低数・最大数が未設定）"
+          />
         </template>
       </div>
     </template>

--- a/resources/js/forms_editor/components/form/QuestionNumber.vue
+++ b/resources/js/forms_editor/components/form/QuestionNumber.vue
@@ -9,12 +9,19 @@
         <p class="form-text text-muted mb-2">
           {{ description }}
         </p>
-        <input
-          type="number"
-          class="form-control"
-          tabindex="-1"
-          placeholder="整数入力"
-        />
+        <template v-if="numberOptions.length > 0">
+          <select class="custom-select" tabindex="-1">
+            <option>整数入力</option>
+            <option v-for="n in numberOptions" :key="n" :value="n">
+              {{ n }}
+            </option>
+          </select>
+        </template>
+        <template v-else>
+          <select class="custom-select" tabindex="-1" disabled>
+            <option>最低数・最大数を設定してください</option>
+          </select>
+        </template>
       </div>
     </template>
     <template v-slot:edit-panel>
@@ -57,6 +64,18 @@ export default {
     },
     is_required() {
       return this.question.is_required;
+    },
+    numberOptions() {
+      const min = this.question.number_min;
+      const max = this.question.number_max;
+      if (min == null || max == null || min > max) {
+        return [];
+      }
+      const options = [];
+      for (let i = min; i <= max; i++) {
+        options.push(i);
+      }
+      return options;
     },
   },
 };

--- a/resources/js/v2/components/Forms/QuestionItem.vue
+++ b/resources/js/v2/components/Forms/QuestionItem.vue
@@ -158,7 +158,7 @@ export default {
             if (this.numberMax !== null) {
               text += `${this.numberMax}以下`;
             }
-            text += "の値を入力してください";
+            text += "の値を選択してください";
           }
           break;
         }

--- a/resources/js/v2/components/Forms/QuestionNumber.vue
+++ b/resources/js/v2/components/Forms/QuestionNumber.vue
@@ -1,21 +1,35 @@
 <template>
   <select
+    v-if="numberOptions.length > 0"
     :id="inputId"
     :name="inputName"
     class="form-control"
     :required="required"
     :disabled="disabled"
+    :value="value || ''"
   >
-    <option value="" disabled selected hidden>選択してください</option>
+    <option value="" disabled hidden>選択してください</option>
     <option
       v-for="n in numberOptions"
       :key="n"
       :value="n"
-      :selected="String(n) === value"
     >
       {{ n }}
     </option>
   </select>
+  <input
+    v-else
+    type="number"
+    :id="inputId"
+    :name="inputName"
+    class="form-control"
+    :value="value"
+    :required="required"
+    step="1"
+    :min="numberMin"
+    :max="numberMax"
+    :readonly="disabled"
+  />
 </template>
 
 <script>

--- a/resources/js/v2/components/Forms/QuestionNumber.vue
+++ b/resources/js/v2/components/Forms/QuestionNumber.vue
@@ -1,16 +1,21 @@
 <template>
-  <input
-    type="number"
+  <select
     :id="inputId"
     :name="inputName"
     class="form-control"
-    :value="value"
     :required="required"
-    step="1"
-    :min="numberMin"
-    :max="numberMax"
-    :readonly="disabled"
-  />
+    :disabled="disabled"
+  >
+    <option value="" disabled selected hidden>選択してください</option>
+    <option
+      v-for="n in numberOptions"
+      :key="n"
+      :value="n"
+      :selected="String(n) === value"
+    >
+      {{ n }}
+    </option>
+  </select>
 </template>
 
 <script>
@@ -47,6 +52,18 @@ export default {
     disabled: {
       type: Boolean,
       default: false,
+    },
+  },
+  computed: {
+    numberOptions() {
+      if (this.numberMin == null || this.numberMax == null || this.numberMin > this.numberMax) {
+        return [];
+      }
+      const options = [];
+      for (let i = this.numberMin; i <= this.numberMax; i++) {
+        options.push(i);
+      }
+      return options;
     },
   },
 };


### PR DESCRIPTION
- 2025年度理大祭アンケート結果を基に改善
  - 「入力形式ではなくプルダウン式にするなどUIをもう少し使いやすい形式にして欲しい。」
- 備品申請のときなど、整数入力において、上限、下限が設定されている場合はプルダウン形式での入力に変更
- 上限、下限が設定されていない場合は従来通りの入力にフォールバックするようにしています。
  - 新歓のときなどのサークル人数入力の際はテキスト入力の方がいい気がするため。

close #335 

## 表示画面
<img width="723" height="488" alt="スクリーンショット 2026-03-10 18 01 17" src="https://github.com/user-attachments/assets/ec529b70-1080-4cc7-a1a2-9f778c76c41c" />
<img width="723" height="488" alt="スクリーンショット 2026-03-10 18 01 21" src="https://github.com/user-attachments/assets/2d2992f6-63b4-42cc-b254-f04a4e6cc15f" />
