### PR TITLE
Actionsのバージョンを上げる

### DIFF
--- a/.github/workflows/nightly_deploy.yml
+++ b/.github/workflows/nightly_deploy.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
           cache: yarn
@@ -30,7 +30,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
         working-directory: dist
       - name: Cache PHP dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -42,7 +42,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
         working-directory: dist
       - name: Cache PHP dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/testcases.yml
+++ b/.github/workflows/testcases.yml
@@ -47,16 +47,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js (Yarnをインストールするため)
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 16.x
     - name: Install Yarn
       run: npm install -g yarn
     # https://github.com/actions/setup-node/issues/182#issuecomment-966885975
     - name: Use Node.js (Yarnパッケージのキャッシュを有効化するため)
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 16.x
         cache: yarn
@@ -100,16 +100,16 @@ jobs:
         tools: cs2pr
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js (Yarnをインストールするため)
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 16.x
     - name: Install Yarn
       run: npm install -g yarn
     # https://github.com/actions/setup-node/issues/182#issuecomment-966885975
     - name: Use Node.js (Yarnパッケージのキャッシュを有効化するため)
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: 16.x
         cache: yarn
@@ -119,7 +119,7 @@ jobs:
       id: composer-cache
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - name: Cache PHP dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -135,7 +135,7 @@ jobs:
     - name: PHPUnitでテスト実行
       run: vendor/bin/phpunit --coverage-clover=coverage.xml
     - name: コードカバレッジを送信
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         files: ./coverage.xml
         verbose: true


### PR DESCRIPTION
- Actionsのバージョンを上げないと、プルリク送った際にテストが実行されないので...
- actions/create-release@v1 と actions/upload-release-asset@v1 はアーカイブ済みで、softprops/action-gh-release への移行が推奨らしい
  - ただ、ロジック変更を伴うっぽいから保留