### PR TITLE
マークダウン回答の追加

### DIFF
--- a/app/Eloquents/Question.php
+++ b/app/Eloquents/Question.php
@@ -33,6 +33,7 @@ class Question extends Model
         'text',
         'number',
         'textarea',
+        'markdown',
         'radio',
         'checkbox',
         'select',

--- a/app/GridMakers/Helpers/AnswerDetailsHelper.php
+++ b/app/GridMakers/Helpers/AnswerDetailsHelper.php
@@ -8,7 +8,7 @@ use App\Eloquents\AnswerDetail;
 use App\Eloquents\Form;
 use App\Eloquents\Question;
 use App\GridMakers\Filter\FilterableKey;
-use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Query\JoinClause;
 

--- a/app/GridMakers/Helpers/AnswerDetailsHelper.php
+++ b/app/GridMakers/Helpers/AnswerDetailsHelper.php
@@ -46,6 +46,7 @@ class AnswerDetailsHelper
                         return "MAX(CAST(CASE WHEN question_id = {$idInt} THEN answer ELSE NULL END AS DECIMAL(10, 0))) AS '{$columnAlias}'";
                     case 'text':
                     case 'textarea':
+                    case 'markdown':
                     case 'radio':
                     case 'select':
                     case 'upload':
@@ -104,6 +105,7 @@ class AnswerDetailsHelper
                     break;
                 case 'text':
                 case 'textarea':
+                case 'markdown':
                 case 'radio':
                 case 'checkbox':
                 case 'select':

--- a/app/Services/Forms/ValidationRulesService.php
+++ b/app/Services/Forms/ValidationRulesService.php
@@ -37,7 +37,7 @@ class ValidationRulesService
             }
 
             // 型チェック
-            if (in_array($question->type, ['text', 'textarea'], true)) {
+            if (in_array($question->type, ['text', 'textarea', 'markdown'], true)) {
                 $rule[] = 'string';
             } elseif ($question->type === 'checkbox') {
                 $rule[] = 'array';
@@ -49,7 +49,7 @@ class ValidationRulesService
 
             // 文字数・整数値・ファイルサイズ範囲制限
             if (
-                in_array($question->type, ['text', 'textarea', 'number', 'checkbox'], true) &&
+                in_array($question->type, ['text', 'textarea', 'markdown', 'number', 'checkbox'], true) &&
                 isset($question->number_min) && $isStrict
             ) {
                 // upload に対しては、最小ファイルサイズを検証しない
@@ -57,10 +57,15 @@ class ValidationRulesService
             }
 
             if (
-                in_array($question->type, ['text', 'textarea', 'number', 'checkbox', 'upload'], true) &&
+                in_array($question->type, ['text', 'textarea', 'markdown', 'number', 'checkbox', 'upload'], true) &&
                 isset($question->number_max) && $isStrict
             ) {
                 $rule[] = 'max:' . $question->number_max;
+            }
+
+            // markdownタイプで最大文字数が設定されていない場合のデフォルト（余裕を持たせて1000文字程度かデータベースの最大値などにする。今回は安全のため1000とした）
+            if ($question->type === 'markdown' && !isset($question->number_max)) {
+                $rule[] = 'max:1000'; // マークダウンは記号などで文字数を消費しやすいため余裕を持たせる
             }
 
             // ファイルの種類チェック

--- a/app/Services/Forms/ValidationRulesService.php
+++ b/app/Services/Forms/ValidationRulesService.php
@@ -63,11 +63,6 @@ class ValidationRulesService
                 $rule[] = 'max:' . $question->number_max;
             }
 
-            // markdownタイプで最大文字数が設定されていない場合のデフォルト（余裕を持たせて1000文字程度かデータベースの最大値などにする。今回は安全のため1000とした）
-            if ($question->type === 'markdown' && !isset($question->number_max)) {
-                $rule[] = 'max:1000'; // マークダウンは記号などで文字数を消費しやすいため余裕を持たせる
-            }
-
             // ファイルの種類チェック
             if ($question->type === 'upload') {
                 $rule[] = 'mimes:' . \implode(',', $question->allowed_types_array);

--- a/app/Services/Utils/ParseMarkdownService.php
+++ b/app/Services/Utils/ParseMarkdownService.php
@@ -9,6 +9,9 @@ use cebe\markdown\GithubMarkdown as Parser;
 
 class ParseMarkdownService
 {
+    // Markdown のレンダリングは頻繁に呼ばれるため、Purifier は使い回す。
+    private static ?\HTMLPurifier $purifier = null;
+
     public static function render(?string $markdown): string
     {
         if (empty($markdown)) {
@@ -18,12 +21,26 @@ class ParseMarkdownService
         $parser->enableNewlines = true;
         $html = $parser->parse($markdown);
 
-        // XSS対策のため、HTMLPurifier を使ってサニタイズを行う
+        return self::getPurifier()->purify($html);
+    }
+
+    private static function getPurifier(): \HTMLPurifier
+    {
+        // Markdown を描画しないリクエストでは初期化コストがかからないよう遅延生成する。
+        if (self::$purifier === null) {
+            self::$purifier = self::createPurifier();
+        }
+
+        return self::$purifier;
+    }
+
+    private static function createPurifier(): \HTMLPurifier
+    {
+        // render() では「Markdown を HTML に変換してサニタイズする」処理に集中できるよう、設定生成は分離する。
         $config = \HTMLPurifier_Config::createDefault();
         $config->set('Core.Encoding', 'UTF-8');
         $config->set('HTML.Doctype', 'HTML 4.01 Transitional');
-        $purifier = new \HTMLPurifier($config);
 
-        return $purifier->purify($html);
+        return new \HTMLPurifier($config);
     }
 }

--- a/app/Services/Utils/ParseMarkdownService.php
+++ b/app/Services/Utils/ParseMarkdownService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Utils;
 
-use App;
+use Illuminate\Support\Facades\App;
 use cebe\markdown\GithubMarkdown as Parser;
 
 class ParseMarkdownService

--- a/app/Services/Utils/ParseMarkdownService.php
+++ b/app/Services/Utils/ParseMarkdownService.php
@@ -16,6 +16,14 @@ class ParseMarkdownService
         }
         $parser = App::make(Parser::class);
         $parser->enableNewlines = true;
-        return $parser->parse($markdown);
+        $html = $parser->parse($markdown);
+
+        // XSS対策のため、HTMLPurifier を使ってサニタイズを行う
+        $config = \HTMLPurifier_Config::createDefault();
+        $config->set('Core.Encoding', 'UTF-8');
+        $config->set('HTML.Doctype', 'HTML 4.01 Transitional');
+        $purifier = new \HTMLPurifier($config);
+
+        return $purifier->purify($html);
     }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "axios": "^1.6",
         "bootstrap": "^4.6.2",
         "color-convert": "^2.0.1",
+        "dompurify": "^3.3.3",
         "floating-vue": "^2.0.0-beta.24",
         "marked": "^7.0.5",
         "md-editor-v3": "^4.10.0",

--- a/resources/js/forms_editor/components/EditorContent.vue
+++ b/resources/js/forms_editor/components/EditorContent.vue
@@ -68,6 +68,7 @@ import FormHeader from "./form/FormHeader.vue";
 import QuestionText from "./form/QuestionText.vue";
 import QuestionHeading from "./form/QuestionHeading.vue";
 import QuestionTextarea from "./form/QuestionTextarea.vue";
+import QuestionMarkdown from "./form/QuestionMarkdown.vue";
 import QuestionNumber from "./form/QuestionNumber.vue";
 import QuestionUpload from "./form/QuestionUpload.vue";
 import QuestionRadio from "./form/QuestionRadio.vue";
@@ -83,6 +84,7 @@ export default {
     QuestionText,
     QuestionHeading,
     QuestionTextarea,
+    QuestionMarkdown,
     QuestionNumber,
     QuestionUpload,
     QuestionRadio,

--- a/resources/js/forms_editor/components/EditorSidebar.vue
+++ b/resources/js/forms_editor/components/EditorSidebar.vue
@@ -54,6 +54,11 @@ export default {
           label: "複数行入力",
         },
         {
+          value: "markdown",
+          icon: "fab fa-markdown",
+          label: "Markdown入力",
+        },
+        {
           value: "radio",
           icon: "far fa-dot-circle",
           label: "単一選択(ラジオボタン)",

--- a/resources/js/forms_editor/components/form/FormHeader.vue
+++ b/resources/js/forms_editor/components/form/FormHeader.vue
@@ -43,6 +43,7 @@
 
 <script>
 import { marked } from "marked";
+import DOMPurify from "dompurify";
 import FormItem from "./FormItem.vue";
 import { ITEM_HEADER, UPDATE_FORM, SAVE_FORM } from "../../store/editor";
 
@@ -90,7 +91,7 @@ export default {
     },
     description_html() {
       const { description } = this;
-      return marked(description || "");
+      return DOMPurify.sanitize(marked(description || ""));
     },
   },
 };

--- a/resources/js/forms_editor/components/form/QuestionHeading.vue
+++ b/resources/js/forms_editor/components/form/QuestionHeading.vue
@@ -24,6 +24,7 @@
 
 <script>
 import { marked } from "marked";
+import DOMPurify from "dompurify";
 import FormItem from "./FormItem.vue";
 import EditPanel from "./EditPanel.vue";
 import { GET_QUESTION_BY_ID } from "../../store/editor";
@@ -50,7 +51,7 @@ export default {
     },
     description_html() {
       const { description } = this.question;
-      return marked(description || "");
+      return DOMPurify.sanitize(marked(description || ""));
     },
   },
 };

--- a/resources/js/forms_editor/components/form/QuestionMarkdown.vue
+++ b/resources/js/forms_editor/components/form/QuestionMarkdown.vue
@@ -1,0 +1,57 @@
+<template>
+  <form-item :item_id="question_id" type_label="Markdown入力">
+    <template v-slot:content>
+      <div class="form-group mb-0">
+        <label class="mb-1">
+          {{ name }}
+          <span class="badge badge-danger" v-if="is_required">必須</span>
+        </label>
+        <p class="form-text text-muted mb-2">
+          {{ description }}
+        </p>
+        <div class="border p-3 text-muted" style="border-radius: 4px; background: #f8f9fa;">
+          <i class="fab fa-markdown"></i>
+          Markdownエディタがここに表示されます。
+        </div>
+      </div>
+    </template>
+    <template v-slot:edit-panel>
+      <edit-panel :question="question" />
+    </template>
+  </form-item>
+</template>
+
+<script>
+import FormItem from "./FormItem.vue";
+import EditPanel from "./EditPanel.vue";
+import { GET_QUESTION_BY_ID } from "../../store/editor";
+
+export default {
+  props: {
+    question_id: {
+      required: true,
+      type: Number,
+    },
+  },
+  components: {
+    FormItem,
+    EditPanel,
+  },
+  computed: {
+    question() {
+      return this.$store.getters[`editor/${GET_QUESTION_BY_ID}`](
+        this.question_id
+      );
+    },
+    name() {
+      return this.question.name || "(無題の設問)";
+    },
+    description() {
+      return this.question.description;
+    },
+    is_required() {
+      return this.question.is_required;
+    },
+  },
+};
+</script>

--- a/resources/js/v2/components/Forms/QuestionItem.vue
+++ b/resources/js/v2/components/Forms/QuestionItem.vue
@@ -39,6 +39,7 @@ import AppBadge from "../AppBadge.vue";
 
 import QuestionText from "./QuestionText.vue";
 import QuestionTextarea from "./QuestionTextarea.vue";
+import QuestionMarkdown from "./QuestionMarkdown.vue";
 import QuestionUpload from "./QuestionUpload.vue";
 import QuestionNumber from "./QuestionNumber.vue";
 import QuestionSelect from "./QuestionSelect.vue";
@@ -51,6 +52,7 @@ export default {
     AppBadge,
     QuestionText,
     QuestionTextarea,
+    QuestionMarkdown,
     QuestionUpload,
     QuestionNumber,
     QuestionSelect,
@@ -138,7 +140,8 @@ export default {
       let text = "";
       switch (this.type) {
         case "text":
-        case "textarea": {
+        case "textarea":
+        case "markdown": {
           if (this.numberMin !== null || this.numberMax !== null) {
             if (this.numberMin !== null) {
               text += `${this.numberMin}文字以上`;

--- a/resources/js/v2/components/Forms/QuestionMarkdown.vue
+++ b/resources/js/v2/components/Forms/QuestionMarkdown.vue
@@ -4,6 +4,8 @@
       :inputName="inputName"
       :defaultValue="value"
       :id="inputId"
+      :disabled="disabled"
+      :read-only="readOnly || disabled"
     />
   </div>
 </template>
@@ -45,6 +47,10 @@ export default {
       default: null,
     },
     disabled: {
+      type: Boolean,
+      default: false,
+    },
+    readOnly: {
       type: Boolean,
       default: false,
     },

--- a/resources/js/v2/components/Forms/QuestionMarkdown.vue
+++ b/resources/js/v2/components/Forms/QuestionMarkdown.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="question-markdown">
+    <markdown-editor
+      :inputName="inputName"
+      :defaultValue="value"
+      :id="inputId"
+    />
+  </div>
+</template>
+
+<script>
+import MarkdownEditor from "../MarkdownEditor.vue";
+
+export default {
+  components: {
+    MarkdownEditor,
+  },
+  props: {
+    inputId: {
+      type: String,
+      default: null,
+    },
+    inputName: {
+      type: String,
+      default: null,
+    },
+    required: {
+      type: Boolean,
+      default: false,
+    },
+    invalid: {
+      type: String,
+      default: null,
+    },
+    value: {
+      type: String,
+      default: null,
+    },
+    numberMin: {
+      type: Number,
+      default: null,
+    },
+    numberMax: {
+      type: Number,
+      default: null,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+};
+</script>

--- a/resources/js/v2/components/MarkdownEditor.vue
+++ b/resources/js/v2/components/MarkdownEditor.vue
@@ -12,7 +12,6 @@
       :sanitize="sanitize"
       no-iconfont
       ref="editorRef"
-      @onUploadImg="() => {}"
     >
       <template #defToolbars>
         <NormalToolbar title="プレビュー" @onClick="togglePreview">

--- a/resources/js/v2/components/MarkdownEditor.vue
+++ b/resources/js/v2/components/MarkdownEditor.vue
@@ -9,6 +9,7 @@
       :toolbars="toolbars"
       :footers="footers"
       :theme="colorScheme"
+      :sanitize="sanitize"
       no-iconfont
       ref="editorRef"
       @onUploadImg="() => {}"
@@ -39,6 +40,7 @@ import { MdEditor, NormalToolbar, config } from "md-editor-v3";
 import "md-editor-v3/lib/style.css";
 import JA_JP from "@vavt/md-editor-extension/dist/locale/jp-JP";
 import MarkdownEditorIcons from "./MarkdownEditorIcons.vue";
+import DOMPurify from "dompurify";
 
 config({
   editorConfig: {
@@ -136,6 +138,9 @@ export default {
     isDarkQuery.removeEventListener("change", this.handleChangeColorScheme);
   },
   methods: {
+    sanitize(html) {
+      return DOMPurify.sanitize(html);
+    },
     handleChangeColorScheme() {
       const metaColorScheme = document.querySelector("meta[name=color-scheme]")
         .content;

--- a/resources/js/v2/components/MarkdownEditor.vue
+++ b/resources/js/v2/components/MarkdownEditor.vue
@@ -11,6 +11,7 @@
       :theme="colorScheme"
       no-iconfont
       ref="editorRef"
+      @onUploadImg="() => {}"
     >
       <template #defToolbars>
         <NormalToolbar title="プレビュー" @onClick="togglePreview">

--- a/resources/js/v2/components/MarkdownEditor.vue
+++ b/resources/js/v2/components/MarkdownEditor.vue
@@ -10,6 +10,7 @@
       :footers="footers"
       :theme="colorScheme"
       :sanitize="sanitize"
+      :readOnly="isReadOnly"
       no-iconfont
       ref="editorRef"
     >
@@ -29,7 +30,13 @@
         </span>
       </template>
     </md-editor>
-    <input type="hidden" :name="inputName" v-if="inputName" :value="content" />
+    <input
+      type="hidden"
+      :name="inputName"
+      v-if="inputName"
+      :value="content"
+      :disabled="isReadOnly"
+    />
     <MarkdownEditorIcons v-if="shouldRenderIconSvg" />
   </div>
 </template>
@@ -88,6 +95,14 @@ export default {
       type: String,
       default: "",
     },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    readOnly: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -119,6 +134,9 @@ export default {
     },
     footers() {
       return ["markdownTotal", "=", 0];
+    },
+    isReadOnly() {
+      return this.disabled || this.readOnly;
     },
   },
   mounted() {

--- a/resources/views/emails/includes/question_email.blade.php
+++ b/resources/views/emails/includes/question_email.blade.php
@@ -15,6 +15,8 @@
 @endforeach
 @elseif ($question->type === 'upload')
 ✓アップロード済 — [アップロードしたファイルをダウンロード]({{ route('forms.answers.uploads.show', ['form' => $form, 'answer' => $answer, 'question' => $question]) }})
+@elseif ($question->type === 'markdown')
+{!! App\Services\Utils\ParseMarkdownService::render($answer_details[$question->id]) !!}
 @else
 {!! nl2br(e($answer_details[$question->id])) !!}
 @endif

--- a/resources/views/includes/question.blade.php
+++ b/resources/views/includes/question.blade.php
@@ -12,6 +12,14 @@
         <template v-slot:description>{{ $question->description }}</template>
         <pre style="white-space: pre-wrap;">{{ $answer_details[$question->id] ?? '' }}</pre>
     </list-view-form-group>
+@elseif ($question->type === 'markdown' && !empty($is_disabled) && $is_disabled)
+    <list-view-form-group>
+        <template v-slot:label>{{ $question->name }}</template>
+        <template v-slot:description>{{ $question->description }}</template>
+        <div data-turbolinks="false" class="markdown border p-3" style="border-radius: 4px; background: #f8f9fa;">
+            @markdown($answer_details[$question->id] ?? '')
+        </div>
+    </list-view-form-group>
 @else
     {{-- 【v-bind:question-id の値について】 --}}
     {{-- Vue に String ではなく Number 型であると認識させるため --}}

--- a/tests/Unit/Services/Forms/ValidationRulesServiceTest.php
+++ b/tests/Unit/Services/Forms/ValidationRulesServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\Services\Forms;
+
+use App\Eloquents\Form;
+use App\Eloquents\Question;
+use App\Services\Forms\ValidationRulesService;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+class ValidationRulesServiceTest extends TestCase
+{
+    public function testMarkdownWithoutNumberMaxDoesNotApplyImplicitMaxRule(): void
+    {
+        $form = new Form();
+        $question = new Question([
+            'type' => 'markdown',
+            'number_max' => null,
+        ]);
+        $question->id = 1;
+        $form->setRelation('questions', collect([$question]));
+
+        $service = new ValidationRulesService();
+
+        $strict_rules = $service->getRulesFromForm($form, new Request(), true);
+        $draft_rules = $service->getRulesFromForm($form, new Request(), false);
+
+        $this->assertNotContains('max:1000', $strict_rules['answers.' . $question->id]);
+        $this->assertSame(['nullable', 'string'], $draft_rules['answers.' . $question->id]);
+    }
+
+    public function testMarkdownExplicitNumberMaxIsAppliedOnlyForStrictValidation(): void
+    {
+        $form = new Form();
+        $question = new Question([
+            'type' => 'markdown',
+            'number_max' => 1200,
+        ]);
+        $question->id = 1;
+        $form->setRelation('questions', collect([$question]));
+
+        $service = new ValidationRulesService();
+
+        $strict_rules = $service->getRulesFromForm($form, new Request(), true);
+        $draft_rules = $service->getRulesFromForm($form, new Request(), false);
+
+        $this->assertContains('max:1200', $strict_rules['answers.' . $question->id]);
+        $this->assertNotContains('max:1200', $draft_rules['answers.' . $question->id]);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,6 +711,11 @@
   resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
   integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@vavt/md-editor-extension@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@vavt/md-editor-extension/-/md-editor-extension-3.0.0.tgz#23b71c5e46addc312942bc02d2aca8ad0a159942"
@@ -1465,6 +1470,13 @@ domhandler@^5.0.1, domhandler@^5.0.2:
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
+
+dompurify@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.3.tgz#680cae8af3e61320ddf3666a3bc843f7b291b2b6"
+  integrity sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
close #340 

## 📝 概要 / 目的

フォーム機能において、新たに「Markdown記法」で回答できる設問タイプを追加しました。
長文や構造化された回答（見出し、リスト、太字など）を必要とする設問での利便性向上を目的としています。

## ✨ 主な機能・変更点

* フォーム管理画面で設問タイプ「Markdown」を選択・作成できる機能を追加。
* 回答画面にて、Markdownエディタを用いた入力およびプレビュー機能を追加。
* セキュリティ担保のため、バックエンド（PHP）とフロントエンド（Vue）の両方でXSS対策のサニタイズ処理を実装。
* 画像はそもそもアップロードできないっぽい

## 💻 実装内容（詳細）

**1. バックエンド (PHP / Laravel)**

* `Question.php`: 許可される設問タイプ（サポートリスト）に `markdown` を追加。
* `ValidationRulesService.php`: `markdown` タイプに対するバリデーション（文字数制限など）の適用ルールを追加。
* `ParseMarkdownService.php`: `HTMLPurifier` を用いたサーバーサイドのサニタイズ処理を実装。
* `AnswerDetailsHelper.php`: CSV等の各種エクスポート処理におけるマッピングを追加。

**2. フロントエンド (Vue.js)**

* **パッケージ追加:** `dompurify` を導入（フロントエンドのXSS対策用）。
* **管理画面（エディタ）側:**
* `EditorSidebar.vue`: サイドバーの設問追加ボタンの選択肢に「Markdown」を追加。
* `EditorContent.vue`: 展開リストにMarkdownコンポーネントをバインディング。
* `QuestionMarkdown.vue` (管理側/新規作成): 管理画面上で表示されるプレビュー用コンポーネント。


* **回答画面（フロント）側:**
* `QuestionMarkdown.vue` (フロント側/新規作成): 実際の回答画面でユーザーが操作する入力用コンポーネント。
* `QuestionItem.vue`: 回答画面での動的コンポーネント（`<component :is="...">`）の登録処理を追加。
* `MarkdownEditor.vue`: `DOMPurify` を用いたプレビュー時のサニタイズ処理を追加。



**3. ビュー画面 (Blade)**

* `question.blade.php`: 回答内容の確認画面にて、パースされたHTMLを安全に表示するための枠組みを追加。
* `question_email.blade.php`: 送信完了時の控えメール（自動送信メール）に、回答内容をHTML形式で出力する対応を追加。

## 🧪 確認・テスト手順

1. 管理画面のフォーム編集から、設問タイプ「Markdown」を追加して保存できることを確認する。
2. 回答画面にアクセスし、Markdownエディタが表示されることを確認する。
3. エディタ内に `<script>alert(1)</script>` などのタグを入力し、プレビュー時および確認画面移行時にサニタイズ（無害化）され、ポップアップが実行されないことを確認する。
<details><summary>テストコード</summary>

``` markdown
# XSS サニタイズ・テスト

これは通常のテキストです。**太字**や *斜体*、[正常なリンク](https://google.com) は正しく表示される必要があります。

---

## 1. 基本的なスクリプトタグ
最も単純な攻撃パターンです。
<script>alert('XSS 1: スクリプトタグが実行されました！');</script>

## 2. イベントハンドラを利用した攻撃 (imgタグ)
画像が読み込めなかった際のエラーを利用してスクリプトを実行させます。
<img src="invalid-image.jpg" onerror="alert('XSS 2: imgタグのonerrorが実行されました！');">

## 3. マウス操作を利用した攻撃 (aタグ)
リンクにマウスカーソルを合わせた瞬間にスクリプトを実行させます。
<a href="#" onmouseover="alert('XSS 3: aタグのonmouseoverが実行されました！');">ここをホバーしてみてください</a>

## 4. javascript: スキームを利用したリンク
リンク先としてJavaScriptを指定するパターンです。クリックすると実行されます。
[ここをクリック（Markdown記法）](javascript:alert('XSS 4: Markdownのjavascriptリンクが実行されました！'))

<a href="javascript:alert('XSS 5: HTMLのjavascriptリンクが実行されました！')">ここをクリック（HTMLタグ）</a>

## 5. 属性のクォーテーションを省略した攻撃
パーサー（変換器）の隙を突くために、あえて `"` や `'` を外した書き方です。
<img src=x onerror=alert('XSS:6_クォーテーションなしのonerrorが実行されました！')>

## 6. iframe を用いた攻撃
別のページやスクリプトをページ内に埋め込みます。
<iframe src="javascript:alert('XSS 7: iframe内のスクリプトが実行されました！');"></iframe>

---

## 期待される正常な動作（サニタイズ成功時）
この文章が画面に表示された時点で、**1つもポップアップ（alert）が出なければテスト合格**です。
```
</details>

4. フォームを送信し、完了メールおよびCSVエクスポート時に内容が正しく出力されていることを確認する。


<img width="1142" height="1733" alt="スクリーンショット 2026-03-14 2 01 41" src="https://github.com/user-attachments/assets/b4b6f40a-3a14-4034-a66c-b1a2ad6bbeb7" />
<img width="1142" height="1723" alt="スクリーンショット 2026-03-14 2 03 01" src="https://github.com/user-attachments/assets/d3bf4ea5-9249-46e2-9afc-628e11ee5188" />
<img width="1142" height="1723" alt="スクリーンショット 2026-03-14 2 02 32" src="https://github.com/user-attachments/assets/454b980e-e41e-419c-a282-8ea02b127b3a" />
