### PR TITLE
【お問い合わせフォーム】副責任者CCオプション追加と実行委員向けメールのReply-To拡張

### DIFF
--- a/app/Http/Controllers/Contacts/PostAction.php
+++ b/app/Http/Controllers/Contacts/PostAction.php
@@ -29,7 +29,8 @@ class PostAction extends Controller
                 'name' => config('portal.admin_name'),
             ]);
 
-        $this->contactsService->create($circle, $sender, $request->contact_body, $category);
+        // チェックボックス未送信時も既定で共有ONにする（フォーム初期値と合わせる）
+        $this->contactsService->create($circle, $sender, $request->contact_body, $category, $request->boolean('cc_subleader', true));
 
         return to_route('contacts')
             ->with('topAlert.title', 'お問い合わせを受け付けました。')

--- a/app/Http/Requests/ContactFormRequest.php
+++ b/app/Http/Requests/ContactFormRequest.php
@@ -34,6 +34,7 @@ class ContactFormRequest extends FormRequest
         return [
             'circle_id' => ['filled'],
             'contact_body' => ['required'],
+            'cc_subleader' => ['nullable', 'boolean'],
         ];
     }
 

--- a/app/Services/Contacts/ContactsService.php
+++ b/app/Services/Contacts/ContactsService.php
@@ -21,11 +21,30 @@ class ContactsService
      * @param  ContactCategory  $category  お問い合わせ項目
      * @return bool
      */
-    public function create(?Circle $circle, User $sender, string $contactBody, ContactCategory $category)
+    public function create(
+        ?Circle $circle,
+        User $sender,
+        string $contactBody,
+        ContactCategory $category,
+        bool $ccSubleader
+    )
     {
-        if (isset($circle) && is_iterable($circle->users) && count($circle->users) > 0) {
-            // 企画に所属するユーザー全員に確認メールを送信する
-            foreach ($circle->users as $user) {
+        if (isset($circle)) {
+            $recipients = $circle->leader()->get();
+
+            if ($ccSubleader) {
+                // 共有ONの場合のみ副責任者を追加する
+                $recipients = $recipients->concat($circle->users()->wherePivot('is_leader', false)->get());
+            }
+
+            // leader() と users() の結果が重なる可能性があるため user id で重複除外
+            $recipients = $recipients->unique('id');
+
+            if ($recipients->isEmpty()) {
+                $recipients = collect([$sender]);
+            }
+
+            foreach ($recipients as $user) {
                 $this->send($user, $circle, $sender, $contactBody, $category);
             }
         } else {
@@ -33,7 +52,7 @@ class ContactsService
             $this->send($sender, null, $sender, $contactBody, $category);
         }
 
-        $this->sendToStaff($circle, $sender, $contactBody, $category);
+        $this->sendToStaff($circle, $sender, $contactBody, $category, $ccSubleader);
     }
 
     /**
@@ -69,15 +88,34 @@ class ContactsService
      * @param  ContactCategory  $category  お問い合わせ項目
      * @return void
      */
-    private function sendToStaff(?Circle $circle, User $sender, string $contactBody, ContactCategory $category)
+    private function sendToStaff(
+        ?Circle $circle,
+        User $sender,
+        string $contactBody,
+        ContactCategory $category,
+        bool $ccSubleader
+    )
     {
         $senderText = isset($circle) ? $circle->name : $sender->name;
 
-        Mail::to($category->email, $category->name)
-            ->send(
-                (new ContactMailable($circle, $sender, $contactBody, $category))
-                    ->replyTo($sender)
-                    ->subject("お問い合わせ({$senderText} 様)")
+        $mailable = (new ContactMailable($circle, $sender, $contactBody, $category))
+            ->subject("お問い合わせ({$senderText} 様)");
+
+        $replyToUsers = collect([$sender]);
+
+        if (isset($circle) && $ccSubleader) {
+            // スタッフ宛メールの返信先に副責任者も含める
+            $replyToUsers = $replyToUsers->concat(
+                $circle->users()->wherePivot('is_leader', false)->get()
             );
+        }
+
+        // 送信者と副責任者のメールアドレス重複を防ぐ
+        foreach ($replyToUsers->unique('email') as $replyToUser) {
+            $mailable->replyTo($replyToUser->email, $replyToUser->name);
+        }
+
+        Mail::to($category->email, $category->name)
+            ->send($mailable);
     }
 }

--- a/app/Services/Contacts/ContactsService.php
+++ b/app/Services/Contacts/ContactsService.php
@@ -27,8 +27,7 @@ class ContactsService
         string $contactBody,
         ContactCategory $category,
         bool $ccSubleader
-    )
-    {
+    ) {
         if (isset($circle)) {
             $leaders = $circle->leader()->get();
             $subleaders = $circle->users()->wherePivot('is_leader', false)->get();
@@ -102,8 +101,7 @@ class ContactsService
         string $contactBody,
         ContactCategory $category,
         bool $ccSubleader
-    )
-    {
+    ) {
         $senderText = isset($circle) ? $circle->name : $sender->name;
 
         $mailable = (new ContactMailable($circle, $sender, $contactBody, $category))

--- a/app/Services/Contacts/ContactsService.php
+++ b/app/Services/Contacts/ContactsService.php
@@ -8,6 +8,7 @@ use App\Eloquents\Circle;
 use App\Eloquents\ContactCategory;
 use App\Eloquents\User;
 use App\Mail\Contacts\ContactMailable;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Facades\Mail;
 
 class ContactsService
@@ -19,7 +20,8 @@ class ContactsService
      * @param  User  $sender  お問い合わせを作成したユーザー
      * @param  string  $contactBody  お問い合わせ本文
      * @param  ContactCategory  $category  お問い合わせ項目
-     * @return bool
+     * @param  bool  $ccSubleader  副責任者CCを有効にするかどうか
+     * @return void
      */
     public function create(
         ?Circle $circle,
@@ -27,10 +29,16 @@ class ContactsService
         string $contactBody,
         ContactCategory $category,
         bool $ccSubleader
-    ) {
+    ): void {
+        $leaders = null;
+        $subleaders = null;
+
         if (isset($circle)) {
-            $leaders = $circle->leader()->get();
-            $subleaders = $circle->users()->wherePivot('is_leader', false)->get();
+            // メンバーを一度だけ取得し、責任者/副責任者をメモリ上で切り分ける
+            $circle->loadMissing('users');
+            $members = $circle->users;
+            $leaders = $members->filter(fn(User $user) => (bool) $user->pivot->is_leader);
+            $subleaders = $members->reject(fn(User $user) => (bool) $user->pivot->is_leader);
             $isSenderLeader = $leaders->contains('id', $sender->id);
 
             if ($ccSubleader) {
@@ -44,7 +52,7 @@ class ContactsService
                 $recipients = collect([$sender]);
             }
 
-            // leader() と users() の結果が重なる可能性があるため user id で重複除外
+            // 送信先候補が重複した場合に備えて user id で重複除外
             $recipients = $recipients->unique('id');
 
             if ($recipients->isEmpty()) {
@@ -59,7 +67,7 @@ class ContactsService
             $this->send($sender, null, $sender, $contactBody, $category);
         }
 
-        $this->sendToStaff($circle, $sender, $contactBody, $category, $ccSubleader);
+        $this->sendToStaff($circle, $sender, $contactBody, $category, $ccSubleader, $leaders, $subleaders);
     }
 
     /**
@@ -93,6 +101,9 @@ class ContactsService
      * @param  User  $sender  お問い合わせを作成したユーザー
      * @param  string  $contactBody  お問い合わせ本文
      * @param  ContactCategory  $category  お問い合わせ項目
+     * @param  bool  $ccSubleader  副責任者CCを有効にするかどうか
+     * @param  EloquentCollection<int, User>|null  $leaders  企画責任者一覧
+     * @param  EloquentCollection<int, User>|null  $subleaders  企画副責任者一覧
      * @return void
      */
     private function sendToStaff(
@@ -100,7 +111,9 @@ class ContactsService
         User $sender,
         string $contactBody,
         ContactCategory $category,
-        bool $ccSubleader
+        bool $ccSubleader,
+        ?EloquentCollection $leaders = null,
+        ?EloquentCollection $subleaders = null
     ) {
         $senderText = isset($circle) ? $circle->name : $sender->name;
 
@@ -112,9 +125,9 @@ class ContactsService
         if (isset($circle) && $ccSubleader) {
             // スタッフ宛メールの返信先に責任者・副責任者を含める
             $replyToUsers = $replyToUsers->concat(
-                $circle->leader()->get()
+                $leaders ?? collect()
             )->concat(
-                $circle->users()->wherePivot('is_leader', false)->get()
+                $subleaders ?? collect()
             );
         }
 

--- a/app/Services/Contacts/ContactsService.php
+++ b/app/Services/Contacts/ContactsService.php
@@ -30,11 +30,19 @@ class ContactsService
     )
     {
         if (isset($circle)) {
-            $recipients = $circle->leader()->get();
+            $leaders = $circle->leader()->get();
+            $subleaders = $circle->users()->wherePivot('is_leader', false)->get();
+            $isSenderLeader = $leaders->contains('id', $sender->id);
 
             if ($ccSubleader) {
-                // 共有ONの場合のみ副責任者を追加する
-                $recipients = $recipients->concat($circle->users()->wherePivot('is_leader', false)->get());
+                // 共有ON: 責任者・副責任者へ共有する
+                $recipients = $leaders->concat($subleaders);
+            } elseif ($isSenderLeader) {
+                // 共有OFFかつ送信者が責任者: 責任者のみへ送る
+                $recipients = $leaders;
+            } else {
+                // 共有OFFかつ送信者が副責任者: 送信者本人のみに送る
+                $recipients = collect([$sender]);
             }
 
             // leader() と users() の結果が重なる可能性があるため user id で重複除外
@@ -104,13 +112,15 @@ class ContactsService
         $replyToUsers = collect([$sender]);
 
         if (isset($circle) && $ccSubleader) {
-            // スタッフ宛メールの返信先に副責任者も含める
+            // スタッフ宛メールの返信先に責任者・副責任者を含める
             $replyToUsers = $replyToUsers->concat(
+                $circle->leader()->get()
+            )->concat(
                 $circle->users()->wherePivot('is_leader', false)->get()
             );
         }
 
-        // 送信者と副責任者のメールアドレス重複を防ぐ
+        // 送信者・責任者・副責任者のメールアドレス重複を防ぐ
         foreach ($replyToUsers->unique('email') as $replyToUser) {
             $mailable->replyTo($replyToUser->email, $replyToUser->name);
         }

--- a/resources/views/contacts/form.blade.php
+++ b/resources/views/contacts/form.blade.php
@@ -28,6 +28,27 @@
                             </template>
                         @endif
                     </list-view-form-group>
+                    <list-view-form-group label-for="cc_subleader">
+                        <template v-slot:label>返信内容の共有先</template>
+                        <template v-slot:description>
+                            返信内容は企画責任者に共有されます。必要に応じて副責任者にも共有できます。
+                        </template>
+                        {{-- 未チェック時にも 0 を送信して boolean 判定を安定させる --}}
+                        <input type="hidden" name="cc_subleader" value="0">
+                        <div class="form-checkbox">
+                            <label for="cc_subleader" class="form-checkbox__label">
+                                <input type="checkbox" id="cc_subleader" name="cc_subleader" value="1"
+                                    class="form-checkbox__input @error('cc_subleader') is-invalid @enderror"
+                                    {{ old('cc_subleader', '1') === '1' ? 'checked' : '' }}>
+                                副責任者にもメールで共有する（CC）
+                            </label>
+                        </div>
+                        @error('cc_subleader')
+                            <template v-slot:invalid>
+                                {{ $message }}
+                            </template>
+                        @enderror
+                    </list-view-form-group>
                 @else
                     <list-view-form-group label-for="name">
                         <template v-slot:label>名前</template>

--- a/resources/views/contacts/form.blade.php
+++ b/resources/views/contacts/form.blade.php
@@ -31,7 +31,7 @@
                     <list-view-form-group label-for="cc_subleader">
                         <template v-slot:label>返信内容の共有先</template>
                         <template v-slot:description>
-                            返信内容は企画責任者に共有されます。必要に応じて副責任者にも共有できます。
+                            チェックを外すと送信者のみに確認メールが送信されます。
                         </template>
                         {{-- 未チェック時にも 0 を送信して boolean 判定を安定させる --}}
                         <input type="hidden" name="cc_subleader" value="0">

--- a/resources/views/contacts/form.blade.php
+++ b/resources/views/contacts/form.blade.php
@@ -29,9 +29,9 @@
                         @endif
                     </list-view-form-group>
                     <list-view-form-group label-for="cc_subleader">
-                        <template v-slot:label>返信内容の共有先</template>
+                        <template v-slot:label>問い合わせ内容の共有</template>
                         <template v-slot:description>
-                            チェックを外すと送信者のみに確認メールが送信されます。
+                            チェックを入れると、この問い合わせの控えと実行委員からの返信が企画の責任者および副責任者の全員に共有されます。
                         </template>
                         {{-- 未チェック時にも 0 を送信して boolean 判定を安定させる --}}
                         <input type="hidden" name="cc_subleader" value="0">
@@ -40,7 +40,7 @@
                                 <input type="checkbox" id="cc_subleader" name="cc_subleader" value="1"
                                     class="form-checkbox__input @error('cc_subleader') is-invalid @enderror"
                                     {{ old('cc_subleader', '1') === '1' ? 'checked' : '' }}>
-                                副責任者にもメールで共有する（CC）
+                                企画の責任者・副責任者の全員に共有する（CC）
                             </label>
                         </div>
                         @error('cc_subleader')

--- a/tests/Feature/Http/Controllers/Contacts/PostActionTest.php
+++ b/tests/Feature/Http/Controllers/Contacts/PostActionTest.php
@@ -57,7 +57,7 @@ final class PostActionTest extends TestCase
                 });
         });
 
-        $responce = $this
+        $response = $this
             ->actingAs($this->user)
             ->post(route('contacts.post'), [
                 'circle_id' => $this->circle->id,
@@ -66,6 +66,6 @@ final class PostActionTest extends TestCase
                 'cc_subleader' => '1',
             ]);
 
-        $responce->assertSessionHas('topAlert.title', 'お問い合わせを受け付けました。');
+        $response->assertSessionHas('topAlert.title', 'お問い合わせを受け付けました。');
     }
 }

--- a/tests/Feature/Http/Controllers/Contacts/PostActionTest.php
+++ b/tests/Feature/Http/Controllers/Contacts/PostActionTest.php
@@ -54,8 +54,7 @@ final class PostActionTest extends TestCase
                         && $contactBody === 'テストです！'
                         && $category->id === $this->ContactCategory->id
                         && $ccSubleader === true;
-                })
-                ->andReturn(true);
+                });
         });
 
         $responce = $this

--- a/tests/Feature/Http/Controllers/Contacts/PostActionTest.php
+++ b/tests/Feature/Http/Controllers/Contacts/PostActionTest.php
@@ -46,7 +46,16 @@ final class PostActionTest extends TestCase
     public function contacts_serviceのcreateが呼び出される()
     {
         $this->mock(ContactsService::class, function ($mock) {
-            $mock->shouldReceive('create')->once()->andReturn(true);
+            $mock->shouldReceive('create')
+                ->once()
+                ->withArgs(function ($circle, $sender, $contactBody, $category, $ccSubleader) {
+                    return $circle->id === $this->circle->id
+                        && $sender->id === $this->user->id
+                        && $contactBody === 'テストです！'
+                        && $category->id === $this->ContactCategory->id
+                        && $ccSubleader === true;
+                })
+                ->andReturn(true);
         });
 
         $responce = $this
@@ -55,6 +64,7 @@ final class PostActionTest extends TestCase
                 'circle_id' => $this->circle->id,
                 'contact_body' => 'テストです！',
                 'category' => $this->ContactCategory->id,
+                'cc_subleader' => '1',
             ]);
 
         $responce->assertSessionHas('topAlert.title', 'お問い合わせを受け付けました。');

--- a/tests/Feature/Services/Contacts/ContactsServeceTest.php
+++ b/tests/Feature/Services/Contacts/ContactsServeceTest.php
@@ -59,21 +59,36 @@ final class ContactsServeceTest extends TestCase
         $this->contactCategory = ContactCategory::factory()->create();
     }
 
-    private function create()
+    private function create(bool $ccSubleader = true)
     {
         Mail::fake();
 
-        $this->contactsService->create($this->circle, $this->leader, "こんにちは。\nこれはてすとです。", $this->contactCategory);
+        $this->contactsService->create(
+            $this->circle,
+            $this->leader,
+            "こんにちは。\nこれはてすとです。",
+            $this->contactCategory,
+            $ccSubleader
+        );
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
     public function send_お問い合わせが企画のメンバーに送信できる()
     {
-        $this->create();
+        $this->create(true);
 
         Mail::assertSent(ContactMailable::class, fn($mail) => $mail->hasTo($this->leader->email));
 
         Mail::assertSent(ContactMailable::class, fn($mail) => $mail->hasTo($this->member->email));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function send_副責任者へのccを無効にした場合は企画責任者のみに送信される()
+    {
+        $this->create(false);
+
+        Mail::assertSent(ContactMailable::class, fn($mail) => $mail->hasTo($this->leader->email));
+        Mail::assertNotSent(ContactMailable::class, fn($mail) => $mail->hasTo($this->member->email));
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
@@ -82,5 +97,66 @@ final class ContactsServeceTest extends TestCase
         $this->create();
 
         Mail::assertSent(ContactMailable::class, fn($mail) => $mail->hasTo($this->contactCategory->email));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function send_to_staff_副責任者ccが有効ならreply_toに送信者と副責任者が含まれる()
+    {
+        $this->create(true);
+
+        Mail::assertSent(ContactMailable::class, fn($mail) => $mail->hasTo($this->contactCategory->email)
+            && $mail->hasReplyTo($this->leader->email, $this->leader->name)
+            && $mail->hasReplyTo($this->member->email, $this->member->name));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function send_to_staff_副責任者ccが無効ならreply_toは送信者のみになる()
+    {
+        $this->create(false);
+
+        Mail::assertSent(ContactMailable::class, fn($mail) => $mail->hasTo($this->contactCategory->email)
+            && $mail->hasReplyTo($this->leader->email, $this->leader->name)
+            && ! $mail->hasReplyTo($this->member->email, $this->member->name));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function send_to_staff_送信者が副責任者でもreply_toに重複がない()
+    {
+        Mail::fake();
+
+        $this->contactsService->create(
+            $this->circle,
+            $this->member,
+            "こんにちは。\nこれはてすとです。",
+            $this->contactCategory,
+            true
+        );
+
+        Mail::assertSent(ContactMailable::class, function ($mail) {
+            if (! $mail->hasTo($this->contactCategory->email)) {
+                return false;
+            }
+
+            $replyToAddresses = collect($mail->replyTo)->pluck('address');
+
+            return $mail->hasReplyTo($this->member->email, $this->member->name)
+                && $replyToAddresses->count() === $replyToAddresses->unique()->count();
+        });
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function send_企画未選択の場合は送信者本人に送信される()
+    {
+        Mail::fake();
+
+        $this->contactsService->create(
+            null,
+            $this->leader,
+            "こんにちは。\nこれはてすとです。",
+            $this->contactCategory,
+            true
+        );
+
+        Mail::assertSent(ContactMailable::class, fn($mail) => $mail->hasTo($this->leader->email));
     }
 }

--- a/tests/Feature/Services/Contacts/ContactsServeceTest.php
+++ b/tests/Feature/Services/Contacts/ContactsServeceTest.php
@@ -120,6 +120,23 @@ final class ContactsServeceTest extends TestCase
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
+    public function send_副責任者がcc無効で送信した場合は責任者へ送信されない()
+    {
+        Mail::fake();
+
+        $this->contactsService->create(
+            $this->circle,
+            $this->member,
+            "こんにちは。\nこれはてすとです。",
+            $this->contactCategory,
+            false
+        );
+
+        Mail::assertSent(ContactMailable::class, fn($mail) => $mail->hasTo($this->member->email));
+        Mail::assertNotSent(ContactMailable::class, fn($mail) => $mail->hasTo($this->leader->email));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
     public function send_to_staff_送信者が副責任者でもreply_toに重複がない()
     {
         Mail::fake();
@@ -139,7 +156,8 @@ final class ContactsServeceTest extends TestCase
 
             $replyToAddresses = collect($mail->replyTo)->pluck('address');
 
-            return $mail->hasReplyTo($this->member->email, $this->member->name)
+            return $mail->hasReplyTo($this->leader->email, $this->leader->name)
+                && $mail->hasReplyTo($this->member->email, $this->member->name)
                 && $replyToAddresses->count() === $replyToAddresses->unique()->count();
         });
     }


### PR DESCRIPTION
close s-union/PortalDots#320 

## 概要

- お問い合わせフォームに「企画の責任者・副責任者の全員に共有する（CC）」チェックボックスを追加（初期値ON）。
- cc_subleader がONのとき、実行委員宛メール（スタッフ向け控え）の Reply-To に副責任者を追加。
  - 副責任者がお問い合わせをした場合はReply-Toに責任者を追加するようにした。
- 既存の問い合わせ確認メール送信ロジックを見直し、宛先重複を除外するように。

## 変更内容
### フロント

1. お問い合わせフォームに cc_subleader チェックボックス追加（hidden 0 + checkbox 1 で確実に送信）。
2. 「チェックを入れると、この問い合わせの控えと実行委員からの返信が企画の責任者および副責任者の全員に共有されます。」という説明を追加。

### バックエンド

1. ContactFormRequest に cc_subleader（boolean）を追加。
2. PostAction から ContactsService::create(..., bool $ccSubleader) へ値を引き渡し。
3. ContactsService::create の送信先を分岐。
4. sendToStaff を拡張し、cc_subleader=true かつ企画ありの場合に副責任者を Reply-To へ追加。
5. Reply-To は送信者を常に含み、メールアドレス重複を除外。

## 控えメール送信先（問い合わせ者側）
ContactsService::create の送信先を次の仕様で分岐:

- 責任者が送信 + チェック ON
  - 送信先: 責任者 + 副責任者
- 責任者が送信 + チェック OFF
  - 送信先: 責任者のみ
- 副責任者が送信 + チェック ON
  - 送信先: 責任者 + 副責任者
- 副責任者が送信 + チェック OFF
  - 送信先: 副責任者のみ

※ 送信対象はユーザーIDで重複除外

## スタッフ向け控え (sendToStaff) の Reply-To

- 常に送信者を含む
- cc_subleader=true かつ circle ありの場合、責任者 + 副責任者を追加
- メールアドレス重複を除外して Reply-To を設定

## 影響範囲

- お問い合わせ機能のみ（UI/バリデーション/送信ロジック）。
- DBスキーマ変更なし。
- 外部API変更なし。

## テスト

- 追加・更新

1. ContactsServeceTest
2. PostActionTest
