### PR TITLE
Fix/form timezone bug

### DIFF
--- a/app/Http/Controllers/Staff/Forms/Editor/UpdateFormAction.php
+++ b/app/Http/Controllers/Staff/Forms/Editor/UpdateFormAction.php
@@ -13,20 +13,19 @@ class UpdateFormAction extends Controller
     {
     }
 
-    public function __invoke(int $form_id, UpdateFormRequest $request)
+    public function __invoke(Form $form, UpdateFormRequest $request)
     {
-        $form = $request->form;
+        $validated = $request->validated();
+        $input = $validated['form'];
 
         // 参加登録フォームのフォーム情報は修正禁止
-        if (isset(Form::findOrFail($form['id'])->participationType)) {
+        if (isset($form->participationType)) {
             return abort(400);
         }
 
-        unset($form['created_at'], $form['updated_at'], $form['custom_form'], $form['id']);
-
         $this->formEditorService->updateForm(
-            $form_id,
-            $form
+            $form->id,
+            $input
         );
     }
 }

--- a/app/Http/Controllers/Staff/Forms/Editor/UpdateFormAction.php
+++ b/app/Http/Controllers/Staff/Forms/Editor/UpdateFormAction.php
@@ -15,6 +15,7 @@ class UpdateFormAction extends Controller
 
     public function __invoke(Form $form, UpdateFormRequest $request)
     {
+        // バリデーション済みデータのみを受け取り、想定外のキー混入を防ぐ
         $validated = $request->validated();
         $input = $validated['form'];
 
@@ -23,6 +24,7 @@ class UpdateFormAction extends Controller
             return abort(400);
         }
 
+        // ルートバインド済みの Form を正として更新対象を確定する
         $this->formEditorService->updateForm(
             $form->id,
             $input

--- a/app/Services/Forms/FormEditorService.php
+++ b/app/Services/Forms/FormEditorService.php
@@ -20,6 +20,7 @@ class FormEditorService
     {
         $eloquent = Form::findOrFail($form_id);
 
+        // editor 以外の更新経路では open_at / close_at が未指定の場合があるため、存在時のみ変換する
         if (array_key_exists('open_at', $form)) {
             $form['open_at'] = new Carbon($form['open_at']);
         }
@@ -28,6 +29,7 @@ class FormEditorService
             $form['close_at'] = new Carbon($form['close_at']);
         }
 
+        // fill により更新対象フィールドを一括反映する
         $eloquent->fill($form);
         $eloquent->save();
     }

--- a/app/Services/Forms/FormEditorService.php
+++ b/app/Services/Forms/FormEditorService.php
@@ -14,12 +14,20 @@ class FormEditorService
      *
      * @param  int  $form_id  フォームID
      * @param  array  $form  フォーム情報配列
+     * @return void
      */
-    public function updateForm(int $form_id, array $form)
+    public function updateForm(int $form_id, array $form): void
     {
         $eloquent = Form::findOrFail($form_id);
-        $form['open_at'] = new Carbon($form['open_at']);
-        $form['close_at'] = new Carbon($form['close_at']);
+
+        if (array_key_exists('open_at', $form)) {
+            $form['open_at'] = new Carbon($form['open_at']);
+        }
+
+        if (array_key_exists('close_at', $form)) {
+            $form['close_at'] = new Carbon($form['close_at']);
+        }
+
         $eloquent->fill($form);
         $eloquent->save();
     }

--- a/resources/js/forms_editor/store/editor.js
+++ b/resources/js/forms_editor/store/editor.js
@@ -235,7 +235,15 @@ export default {
     },
     async [SAVE_FORM]({ state, commit, dispatch }) {
       dispatch(START_SAVING)
-      await API.update_form(state.form).catch((e) => {
+      // 受付期間(open_at/close_at)はフォームエディタでは編集対象外のため送信しない
+      const form = {
+        id: state.form.id,
+        name: state.form.name,
+        description: state.form.description,
+        is_public: state.form.is_public,
+        max_answers: state.form.max_answers
+      }
+      await API.update_form(form).catch((e) => {
         if (e.status === UNPROCESSABLE_ENTITY) {
           commit(
             `status/${SET_VALIDATION_ERROR}`,

--- a/resources/js/forms_editor/store/editor.js
+++ b/resources/js/forms_editor/store/editor.js
@@ -236,6 +236,7 @@ export default {
     async [SAVE_FORM]({ state, commit, dispatch }) {
       dispatch(START_SAVING)
       // 受付期間(open_at/close_at)はフォームエディタでは編集対象外のため送信しない
+      // 送信フィールドを明示することで、API レスポンス由来の余分なキー送信を防ぐ
       const form = {
         id: state.form.id,
         name: state.form.name,

--- a/tests/Feature/Http/Controllers/Staff/Forms/Editor/UpdateFormActionTest.php
+++ b/tests/Feature/Http/Controllers/Staff/Forms/Editor/UpdateFormActionTest.php
@@ -39,6 +39,7 @@ final class UpdateFormActionTest extends TestCase
     #[\PHPUnit\Framework\Attributes\Test]
     public function フォームエディタ更新時に受付期間が意図せず変更されない()
     {
+        // 既存の受付期間を保持できることを検証する
         $originalOpenAt = $this->form->open_at->copy();
         $originalCloseAt = $this->form->close_at->copy();
 
@@ -59,6 +60,7 @@ final class UpdateFormActionTest extends TestCase
 
         $response->assertStatus(200);
 
+        // 受付期間以外の更新は正常に反映されることを合わせて確認する
         $this->form->refresh();
         $this->assertSame('更新後フォーム', $this->form->name);
         $this->assertSame('更新後説明', $this->form->description);

--- a/tests/Feature/Http/Controllers/Staff/Forms/Editor/UpdateFormActionTest.php
+++ b/tests/Feature/Http/Controllers/Staff/Forms/Editor/UpdateFormActionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Controllers\Staff\Forms\Editor;
+
+use App\Eloquents\Form;
+use App\Eloquents\Permission;
+use App\Eloquents\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class UpdateFormActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Form $form;
+
+    private User $staff;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->form = Form::factory()->create([
+            'name' => '更新前フォーム',
+            'description' => '更新前説明',
+            'open_at' => new CarbonImmutable('2026-04-01 00:00:00'),
+            'close_at' => new CarbonImmutable('2026-04-30 23:59:00'),
+            'max_answers' => 1,
+            'is_public' => true,
+        ]);
+        $this->staff = User::factory()->staff()->create();
+        Permission::create(['name' => 'staff.forms.edit']);
+        $this->staff->syncPermissions(['staff.forms.edit']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function フォームエディタ更新時に受付期間が意図せず変更されない()
+    {
+        $originalOpenAt = $this->form->open_at->copy();
+        $originalCloseAt = $this->form->close_at->copy();
+
+        $response = $this->actingAs($this->staff)
+            ->withSession(['staff_authorized' => true])
+            ->post(route('staff.forms.editor.api', ['form' => $this->form]) . '/update_form', [
+                'form' => [
+                    'id' => $this->form->id,
+                    'name' => '更新後フォーム',
+                    'description' => '更新後説明',
+                    'is_public' => false,
+                    'max_answers' => 3,
+                    // editor API が返しがちな UTC 文字列を敢えて混入させる
+                    'open_at' => $originalOpenAt->copy()->utc()->format('Y-m-d\TH:i:s.u\Z'),
+                    'close_at' => $originalCloseAt->copy()->utc()->format('Y-m-d\TH:i:s.u\Z'),
+                ],
+            ]);
+
+        $response->assertStatus(200);
+
+        $this->form->refresh();
+        $this->assertSame('更新後フォーム', $this->form->name);
+        $this->assertSame('更新後説明', $this->form->description);
+        $this->assertFalse($this->form->is_public);
+        $this->assertSame(3, $this->form->max_answers);
+        $this->assertSame($originalOpenAt->format('Y-m-d H:i:s'), $this->form->open_at->format('Y-m-d H:i:s'));
+        $this->assertSame($originalCloseAt->format('Y-m-d H:i:s'), $this->form->close_at->format('Y-m-d H:i:s'));
+    }
+}

--- a/tests/Feature/Services/Forms/FormEditorServiceTest.php
+++ b/tests/Feature/Services/Forms/FormEditorServiceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services\Forms;
+
+use App\Eloquents\Form;
+use App\Services\Forms\FormEditorService;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Tests\TestCase;
+
+final class FormEditorServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private FormEditorService $formEditorService;
+
+    private Form $form;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->formEditorService = App::make(FormEditorService::class);
+        $this->form = Form::factory()->create([
+            'open_at' => new CarbonImmutable('2026-05-01 00:00:00'),
+            'close_at' => new CarbonImmutable('2026-05-31 23:59:00'),
+        ]);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function open_atとclose_atが渡された場合は受付期間を更新できる()
+    {
+        $this->formEditorService->updateForm($this->form->id, [
+            'open_at' => '2026-06-01 00:00:00',
+            'close_at' => '2026-06-30 23:59:00',
+        ]);
+
+        $this->form->refresh();
+        $this->assertSame('2026-06-01 00:00:00', $this->form->open_at->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-06-30 23:59:00', $this->form->close_at->format('Y-m-d H:i:s'));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function open_atとclose_atが未指定の場合は受付期間を保持したまま更新できる()
+    {
+        $originalOpenAt = $this->form->open_at->copy();
+        $originalCloseAt = $this->form->close_at->copy();
+
+        $this->formEditorService->updateForm($this->form->id, [
+            'name' => '更新後フォーム',
+            'description' => '更新後説明',
+            'is_public' => false,
+            'max_answers' => 3,
+        ]);
+
+        $this->form->refresh();
+        $this->assertSame('更新後フォーム', $this->form->name);
+        $this->assertSame('更新後説明', $this->form->description);
+        $this->assertFalse($this->form->is_public);
+        $this->assertSame(3, $this->form->max_answers);
+        $this->assertSame($originalOpenAt->format('Y-m-d H:i:s'), $this->form->open_at->format('Y-m-d H:i:s'));
+        $this->assertSame($originalCloseAt->format('Y-m-d H:i:s'), $this->form->close_at->format('Y-m-d H:i:s'));
+    }
+}

--- a/tests/Feature/Services/Forms/FormEditorServiceTest.php
+++ b/tests/Feature/Services/Forms/FormEditorServiceTest.php
@@ -33,6 +33,7 @@ final class FormEditorServiceTest extends TestCase
     #[\PHPUnit\Framework\Attributes\Test]
     public function open_atとclose_atが渡された場合は受付期間を更新できる()
     {
+        // 指定ありの場合は従来どおり受付期間を更新する
         $this->formEditorService->updateForm($this->form->id, [
             'open_at' => '2026-06-01 00:00:00',
             'close_at' => '2026-06-30 23:59:00',
@@ -46,6 +47,7 @@ final class FormEditorServiceTest extends TestCase
     #[\PHPUnit\Framework\Attributes\Test]
     public function open_atとclose_atが未指定の場合は受付期間を保持したまま更新できる()
     {
+        // 指定なしの場合は受付期間を保持し、他項目のみ更新する
         $originalOpenAt = $this->form->open_at->copy();
         $originalCloseAt = $this->form->close_at->copy();
 


### PR DESCRIPTION
申請フォームにおいて、なぜか申請期間が勝手に変わる問題のバグ修正

> ### なぜか申請期間が勝手に変わるのをなんとかしたい
> -  編集すると高確率で変わってる、なんで？？？？？？？
>     - ◯月◯日0:00~〇月〇日23:59→ ◯月◯日<font color = red>15:00</font>~〇月〇日<font color = red>14:59</font>になりがち
>     - グリニッジ？？？１日違うけど
>     - ひどい時は日付も変わってる
> - フォームエディタに入って編集すると時間が勝手に変わる
> - アクティビティログを見ると、アクティビティログ自体も9時間ずれてる
>     - 23:59って設定しても、アクティビティログを見ると14:59って設定したことになってる
> - ページ遷移するとタイムゾーンを設定し直す必要がある
>     - フォームエディターに入ったときにタイムゾーンがリセットされたままになってる 
>     - 申請管理の画面ではタイムゾーンが日本になってる（表示させる時にタイムゾーンの設定がされる）
>     - フォームエディターではタイムゾーンが設定されていない？
>
> 新歓ウェブポータルの仕様について - 新歓/2023/システム/ウェブポータル
https://s-union.esa.io/posts/5726
