### PR TITLE
feat: port s-union/6.x features — markdown question, number select, contact ccSubleader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,32 @@ jobs:
       - name: Check
         run: mise run frontend:check
 
+  frontend-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install JS dependencies
+        run: mise run frontend:install
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @portaldots/frontend exec playwright install --with-deps chromium
+
+      - name: Generate API client
+        run: mise run api:client:codegen
+
+      - name: Build (generates typed-router.d.ts)
+        run: pnpm --filter @portaldots/frontend run build
+
+      - name: Test
+        run: mise run frontend:test
+
   email-producer-check:
     runs-on: ubuntu-latest
     steps:
@@ -51,6 +77,23 @@ jobs:
       - name: Check
         run: mise run email:producer:check
 
+  email-producer-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install JS dependencies
+        run: mise run frontend:install
+
+      - name: Test
+        run: mise run email:producer:test
+
   email-consumer-check:
     runs-on: ubuntu-latest
     steps:
@@ -67,6 +110,23 @@ jobs:
 
       - name: Check
         run: mise run email:consumer:check
+
+  email-consumer-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install JS dependencies
+        run: mise run frontend:install
+
+      - name: Test
+        run: mise run email:consumer:test
 
   backend-check:
     runs-on: ubuntu-latest

--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -3,8 +3,7 @@ tmp_dir = "tmp"
 
 [build]
   cmd = "go build -o ./tmp/api ."
-  bin = "./tmp/api"
-  full_bin = "./tmp/api"
+  entrypoint = ["./tmp/api"]
   include_ext = ["go", "tpl", "tmpl", "html"]
   exclude_dir = ["tmp", "vendor", "testdata"]
   exclude_regex = ["_test\\.go"]

--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -429,6 +429,9 @@ paths:
                 body:
                   type: string
                   minLength: 1
+                ccSubleader:
+                  type: boolean
+                  default: true
       responses:
         "201":
           description: Submitted contact

--- a/backend/internal/controllers/contact_profile.go
+++ b/backend/internal/controllers/contact_profile.go
@@ -25,9 +25,10 @@ type participantContactCategoryResponse struct {
 }
 
 type submitContactRequest struct {
-	CategoryID string `json:"categoryId"`
-	Subject    string `json:"subject"`
-	Body       string `json:"body"`
+	CategoryID  string `json:"categoryId"`
+	Subject     string `json:"subject"`
+	Body        string `json:"body"`
+	CCSubleader *bool  `json:"ccSubleader"`
 }
 
 type submitContactResponse struct {
@@ -184,7 +185,11 @@ func (h *authHandlers) submitContact(c echo.Context) error {
 		request.Body,
 	)
 
-	confirmationRecipients, err := h.contactConfirmationRecipients(selectedCircleID(selectedCircle), currentSession.User.ID)
+	confirmationRecipients, err := h.contactConfirmationRecipients(
+		selectedCircleID(selectedCircle),
+		currentSession.User.ID,
+		contactShouldCCSubleader(request.CCSubleader),
+	)
 	if err != nil {
 		return internalError(c)
 	}
@@ -263,13 +268,13 @@ func (h *authHandlers) submitContact(c echo.Context) error {
 	})
 }
 
-func (h *authHandlers) contactConfirmationRecipients(circleID, senderUserID string) ([]string, error) {
+func (h *authHandlers) contactConfirmationRecipients(circleID, senderUserID string, ccSubleader bool) ([]string, error) {
 	if strings.TrimSpace(circleID) != "" {
 		users, err := h.users.ListByCircleIDs([]string{circleID})
 		if err != nil {
 			return nil, err
 		}
-		recipients := collectUsersEmailRecipients(users)
+		recipients := contactCircleConfirmationRecipients(users, circleID, senderUserID, ccSubleader)
 		if len(recipients) > 0 {
 			return recipients, nil
 		}
@@ -291,6 +296,40 @@ func (h *authHandlers) contactConfirmationRecipients(circleID, senderUserID stri
 	}
 
 	return nil, nil
+}
+
+func contactShouldCCSubleader(value *bool) bool {
+	if value == nil {
+		return true
+	}
+	return *value
+}
+
+func contactCircleConfirmationRecipients(users []useradmin.User, circleID, senderUserID string, ccSubleader bool) []string {
+	leaders := make([]useradmin.User, 0, len(users))
+	subleaders := make([]useradmin.User, 0, len(users))
+	var senderUser *useradmin.User
+
+	for index := range users {
+		userValue := users[index]
+		if userValue.ID == senderUserID {
+			senderUser = &users[index]
+		}
+		if slices.Contains(userValue.LeaderCircleIDs, circleID) {
+			leaders = append(leaders, userValue)
+			continue
+		}
+		subleaders = append(subleaders, userValue)
+	}
+
+	if ccSubleader {
+		return collectUsersEmailRecipients(append(leaders, subleaders...))
+	}
+	if senderUser != nil && !slices.Contains(senderUser.LeaderCircleIDs, circleID) {
+		return collectUsersEmailRecipients([]useradmin.User{*senderUser})
+	}
+
+	return collectUsersEmailRecipients(leaders)
 }
 
 func selectedCircleID(selectedCircle *circleInfo) string {

--- a/backend/internal/controllers/contact_profile.go
+++ b/backend/internal/controllers/contact_profile.go
@@ -325,7 +325,7 @@ func contactCircleConfirmationRecipients(users []useradmin.User, circleID, sende
 	if ccSubleader {
 		return collectUsersEmailRecipients(append(leaders, subleaders...))
 	}
-	if senderUser != nil && !slices.Contains(senderUser.LeaderCircleIDs, circleID) {
+	if senderUser != nil {
 		return collectUsersEmailRecipients([]useradmin.User{*senderUser})
 	}
 

--- a/backend/internal/controllers/contact_profile_test.go
+++ b/backend/internal/controllers/contact_profile_test.go
@@ -44,14 +44,31 @@ func TestContactCircleConfirmationRecipients(t *testing.T) {
 		t.Fatalf("expected leader and subleader recipients, got %#v", withSubleader)
 	}
 
-	leaderOnly := contactCircleConfirmationRecipients(users, "circle-a", "leader", false)
-	if !slices.Equal(leaderOnly, []string{"leader@example.com"}) {
-		t.Fatalf("expected leader-only recipients, got %#v", leaderOnly)
+	senderOnlyLeader := contactCircleConfirmationRecipients(users, "circle-a", "leader", false)
+	if !slices.Equal(senderOnlyLeader, []string{"leader@example.com"}) {
+		t.Fatalf("expected sender-only (leader) recipient, got %#v", senderOnlyLeader)
 	}
 
-	senderOnly := contactCircleConfirmationRecipients(users, "circle-a", "subleader", false)
-	if !slices.Equal(senderOnly, []string{"subleader@example.com"}) {
-		t.Fatalf("expected subleader sender recipient, got %#v", senderOnly)
+	senderOnlySubleader := contactCircleConfirmationRecipients(users, "circle-a", "subleader", false)
+	if !slices.Equal(senderOnlySubleader, []string{"subleader@example.com"}) {
+		t.Fatalf("expected sender-only (subleader) recipient, got %#v", senderOnlySubleader)
+	}
+
+	// 複数リーダーがいても ccSubleader=false のとき送信者のみに送る
+	multiLeaderUsers := []useradmin.User{
+		{
+			ID:              "leader2",
+			DisplayName:     "Leader2",
+			ContactEmail:    "leader2@example.com",
+			LeaderCircleIDs: []string{"circle-a"},
+			IsEmailVerified: true,
+		},
+		users[0], // leader
+		users[1], // subleader
+	}
+	multiLeaderSenderOnly := contactCircleConfirmationRecipients(multiLeaderUsers, "circle-a", "leader", false)
+	if !slices.Equal(multiLeaderSenderOnly, []string{"leader@example.com"}) {
+		t.Fatalf("expected sender-only even with multiple leaders, got %#v", multiLeaderSenderOnly)
 	}
 }
 

--- a/backend/internal/controllers/contact_profile_test.go
+++ b/backend/internal/controllers/contact_profile_test.go
@@ -1,6 +1,11 @@
 package controllers
 
-import "testing"
+import (
+	"slices"
+	"testing"
+
+	"github.com/s-union/PortalDots/backend/internal/domain/useradmin"
+)
 
 func TestContactHistoryMatchesRenamedCircleAndUser(t *testing.T) {
 	t.Parallel()
@@ -12,5 +17,53 @@ func TestContactHistoryMatchesRenamedCircleAndUser(t *testing.T) {
 
 	if contactHistoryMatches(body, "0195ec00-0022-7000-8000-000000000001", "0195ec00-0051-7000-8000-000000000001") {
 		t.Fatal("expected different circle ID not to match")
+	}
+}
+
+func TestContactCircleConfirmationRecipients(t *testing.T) {
+	t.Parallel()
+
+	users := []useradmin.User{
+		{
+			ID:              "leader",
+			DisplayName:     "Leader",
+			ContactEmail:    "leader@example.com",
+			LeaderCircleIDs: []string{"circle-a"},
+			IsEmailVerified: true,
+		},
+		{
+			ID:              "subleader",
+			DisplayName:     "Subleader",
+			ContactEmail:    "subleader@example.com",
+			IsEmailVerified: true,
+		},
+	}
+
+	withSubleader := contactCircleConfirmationRecipients(users, "circle-a", "leader", true)
+	if !slices.Equal(withSubleader, []string{"leader@example.com", "subleader@example.com"}) {
+		t.Fatalf("expected leader and subleader recipients, got %#v", withSubleader)
+	}
+
+	leaderOnly := contactCircleConfirmationRecipients(users, "circle-a", "leader", false)
+	if !slices.Equal(leaderOnly, []string{"leader@example.com"}) {
+		t.Fatalf("expected leader-only recipients, got %#v", leaderOnly)
+	}
+
+	senderOnly := contactCircleConfirmationRecipients(users, "circle-a", "subleader", false)
+	if !slices.Equal(senderOnly, []string{"subleader@example.com"}) {
+		t.Fatalf("expected subleader sender recipient, got %#v", senderOnly)
+	}
+}
+
+func TestContactShouldCCSubleaderDefaultsToTrue(t *testing.T) {
+	t.Parallel()
+
+	if !contactShouldCCSubleader(nil) {
+		t.Fatal("expected omitted ccSubleader to preserve shared confirmation behavior")
+	}
+
+	disabled := false
+	if contactShouldCCSubleader(&disabled) {
+		t.Fatal("expected explicit false ccSubleader to disable subleader sharing")
 	}
 }

--- a/backend/internal/controllers/form_answer_helpers_test.go
+++ b/backend/internal/controllers/form_answer_helpers_test.go
@@ -139,6 +139,17 @@ func TestNormalizeAnswerValues(t *testing.T) {
 			wantValues: []string{"hello"},
 			wantErrors: nil,
 		},
+		{
+			name: "markdown validates maximum length",
+			question: formquestion.Question{
+				Type:      "markdown",
+				NumberMax: &max,
+			},
+			rawValue:   "abcdef",
+			hasValue:   true,
+			wantValues: nil,
+			wantErrors: []string{"5 文字以下で入力してください"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/backend/internal/domain/formquestion/repository.go
+++ b/backend/internal/domain/formquestion/repository.go
@@ -16,6 +16,7 @@ var AllowedQuestionTypes = []string{
 	"heading",
 	"text",
 	"textarea",
+	"markdown",
 	"number",
 	"radio",
 	"select",

--- a/backend/internal/domain/formquestion/validation.go
+++ b/backend/internal/domain/formquestion/validation.go
@@ -82,6 +82,14 @@ func NormalizeAnswerValues(question Question, rawValue any, hasValue bool) ([]st
 				return nil, []string{fmt.Sprintf("%d 以下の値を入力してください", *question.NumberMax)}
 			}
 		}
+		if slices.Contains([]string{"text", "textarea", "markdown"}, question.Type) {
+			if question.NumberMin != nil && len([]rune(value)) < int(*question.NumberMin) {
+				return nil, []string{fmt.Sprintf("%d 文字以上で入力してください", *question.NumberMin)}
+			}
+			if question.NumberMax != nil && len([]rune(value)) > int(*question.NumberMax) {
+				return nil, []string{fmt.Sprintf("%d 文字以下で入力してください", *question.NumberMax)}
+			}
+		}
 		if slices.Contains([]string{"radio", "select"}, question.Type) && len(question.Options) > 0 && !slices.Contains(question.Options, value) {
 			return nil, []string{"選択肢の値が不正です"}
 		}

--- a/frontend/.storybook/vitest.setup.ts
+++ b/frontend/.storybook/vitest.setup.ts
@@ -1,2 +1,3 @@
 // Storybookのpreview設定はStorybook 10.3以降、@storybook/addon-vitestが自動的に適用するため、
 // ここではカスタムコードが不要です
+export {}

--- a/frontend/src/components/forms/AnswerQuestionFields.stories.ts
+++ b/frontend/src/components/forms/AnswerQuestionFields.stories.ts
@@ -40,6 +40,15 @@ const textareaQuestion: FormQuestion = {
   type: 'textarea'
 }
 
+const markdownQuestion: FormQuestion = {
+  ...baseQuestion,
+  id: 'q-md',
+  name: '企画紹介文を入力してください',
+  description: '見出し、箇条書き、リンクなどを Markdown で入力できます。',
+  type: 'markdown',
+  numberMax: 1000
+}
+
 const numberQuestion: FormQuestion = {
   ...baseQuestion,
   id: 'q-3',
@@ -117,7 +126,25 @@ export const Textarea: Story = {
   })
 }
 
-export const NumberInput: Story = {
+export const Markdown: Story = {
+  render: () => ({
+    components: { AnswerQuestionFields },
+    setup() {
+      const draft = ref<FormAnswerDraft>({})
+      return { draft, question: markdownQuestion }
+    },
+    template: `
+      <AnswerQuestionFields
+        :answer="null"
+        :draft="draft"
+        :question="question"
+        :download-href="() => ''"
+      />
+    `
+  })
+}
+
+export const NumberSelect: Story = {
   render: () => ({
     components: { AnswerQuestionFields },
     setup() {

--- a/frontend/src/components/forms/AnswerQuestionFields.test.ts
+++ b/frontend/src/components/forms/AnswerQuestionFields.test.ts
@@ -103,6 +103,40 @@ describe('AnswerQuestionFields', () => {
     expect(radioDraft['question-radio']).toBe('いいえ')
   })
 
+  it('updates markdown question draft through the markdown editor', async () => {
+    const question = createQuestion({ id: 'question-markdown', type: 'markdown' })
+    const draft: FormAnswerDraft = { 'question-markdown': '' }
+
+    const wrapper = mount(AnswerQuestionFields, {
+      props: createProps(question, draft)
+    })
+
+    await wrapper.get('textarea[name="question-markdown"]').setValue('**強調** できます')
+
+    expect(draft['question-markdown']).toBe('**強調** できます')
+  })
+
+  it('renders number question as a dropdown from min and max', async () => {
+    const question = createQuestion({
+      id: 'question-number',
+      type: 'number',
+      numberMin: 2,
+      numberMax: 4
+    })
+    const draft: FormAnswerDraft = { 'question-number': '' }
+
+    const wrapper = mount(AnswerQuestionFields, {
+      props: createProps(question, draft)
+    })
+
+    const options = wrapper.findAll('select option')
+    expect(options.map((option) => option.text())).toEqual(['選択してください', '2', '3', '4'])
+
+    await wrapper.get('select').setValue('3')
+
+    expect(draft['question-number']).toBe('3')
+  })
+
   it('renders upload list and emits file events', async () => {
     const question = createQuestion({
       id: 'question-upload',

--- a/frontend/src/components/forms/AnswerQuestionFields.vue
+++ b/frontend/src/components/forms/AnswerQuestionFields.vue
@@ -11,6 +11,7 @@ import {
 } from '@/features/forms/answers'
 import type { FormQuestion } from '@/features/forms/api'
 import ErrorState from '@/components/ui/ErrorState.vue'
+import MarkdownEditorField from '@/components/ui/MarkdownEditorField.vue'
 
 const {
   answer,
@@ -77,6 +78,16 @@ function eventTargetChecked(event: Event) {
   const target = event.target
   return target instanceof HTMLInputElement ? target.checked : false
 }
+
+function questionNumberOptions(currentQuestion: FormQuestion) {
+  const min = currentQuestion.numberMin
+  const max = currentQuestion.numberMax
+  if (min === null || max === null || min > max) {
+    return []
+  }
+
+  return Array.from({ length: max - min + 1 }, (_, index) => min + index)
+}
 </script>
 
 <template>
@@ -98,16 +109,27 @@ function eventTargetChecked(event: Event) {
     @input="setAnswerValue(draft, question, eventTargetValue($event))"
   />
 
-  <input
+  <MarkdownEditorField
+    v-else-if="question.type === 'markdown'"
+    :model-value="String(draftValue())"
+    :disabled="disabled"
+    :name="question.id"
+    min-height-class="min-h-32"
+    @update:model-value="setAnswerValue(draft, question, $event)"
+  />
+
+  <select
     v-else-if="question.type === 'number'"
     :value="String(draftValue())"
     :disabled="disabled"
     :aria-label="question.name"
-    type="number"
-    :min="question.numberMin ?? undefined"
-    :max="question.numberMax ?? undefined"
-    @input="setAnswerValue(draft, question, eventTargetValue($event))"
-  />
+    @change="setAnswerValue(draft, question, eventTargetValue($event))"
+  >
+    <option value="">選択してください</option>
+    <option v-for="option in questionNumberOptions(question)" :key="option" :value="String(option)">
+      {{ option }}
+    </option>
+  </select>
 
   <select
     v-else-if="question.type === 'select'"

--- a/frontend/src/components/forms/AnswerQuestionFields.vue
+++ b/frontend/src/components/forms/AnswerQuestionFields.vue
@@ -79,14 +79,19 @@ function eventTargetChecked(event: Event) {
   return target instanceof HTMLInputElement ? target.checked : false
 }
 
-function questionNumberOptions(currentQuestion: FormQuestion) {
+const MAX_NUMBER_SELECT_OPTIONS = 200
+
+function questionNumberOptions(currentQuestion: FormQuestion): number[] | null {
   const min = currentQuestion.numberMin
   const max = currentQuestion.numberMax
   if (min === null || max === null || min > max) {
-    return []
+    return null
   }
-
-  return Array.from({ length: max - min + 1 }, (_, index) => min + index)
+  const count = max - min + 1
+  if (count > MAX_NUMBER_SELECT_OPTIONS) {
+    return null
+  }
+  return Array.from({ length: count }, (_, index) => min + index)
 }
 </script>
 
@@ -119,17 +124,28 @@ function questionNumberOptions(currentQuestion: FormQuestion) {
   />
 
   <select
-    v-else-if="question.type === 'number'"
+    v-else-if="question.type === 'number' && questionNumberOptions(question) !== null"
     :value="String(draftValue())"
     :disabled="disabled"
     :aria-label="question.name"
     @change="setAnswerValue(draft, question, eventTargetValue($event))"
   >
     <option value="">選択してください</option>
-    <option v-for="option in questionNumberOptions(question)" :key="option" :value="String(option)">
+    <option v-for="option in questionNumberOptions(question)!" :key="option" :value="String(option)">
       {{ option }}
     </option>
   </select>
+
+  <input
+    v-else-if="question.type === 'number'"
+    :value="String(draftValue())"
+    :disabled="disabled"
+    :aria-label="question.name"
+    type="number"
+    :min="question.numberMin ?? undefined"
+    :max="question.numberMax ?? undefined"
+    @input="setAnswerValue(draft, question, eventTargetValue($event))"
+  />
 
   <select
     v-else-if="question.type === 'select'"

--- a/frontend/src/components/staff/forms/FormAnswerPreviewPanel.test.ts
+++ b/frontend/src/components/staff/forms/FormAnswerPreviewPanel.test.ts
@@ -83,6 +83,20 @@ function createForm(overrides: Partial<StaffFormDetail> = {}): StaffFormDetail {
         updatedAt: '2026-03-01T00:00:00Z'
       },
       {
+        id: 'question-markdown',
+        name: '紹介文',
+        description: 'Markdown',
+        type: 'markdown',
+        isRequired: false,
+        numberMin: null,
+        numberMax: 1000,
+        allowedTypes: '',
+        options: [],
+        priority: 5,
+        createdAt: '2026-03-01T00:00:00Z',
+        updatedAt: '2026-03-01T00:00:00Z'
+      },
+      {
         id: 'question-upload',
         name: '添付資料',
         description: 'ファイル',
@@ -92,7 +106,7 @@ function createForm(overrides: Partial<StaffFormDetail> = {}): StaffFormDetail {
         numberMax: null,
         allowedTypes: 'pdf',
         options: [],
-        priority: 5,
+        priority: 6,
         createdAt: '2026-03-01T00:00:00Z',
         updatedAt: '2026-03-01T00:00:00Z'
       }
@@ -104,7 +118,8 @@ function createForm(overrides: Partial<StaffFormDetail> = {}): StaffFormDetail {
       details: {
         'question-checkbox': ['机', '椅子'],
         'question-textarea': ['複数行\nテキスト'],
-        'question-text': ['山田太郎']
+        'question-text': ['山田太郎'],
+        'question-markdown': ['**太字** の紹介文']
       },
       uploads: [
         {
@@ -140,6 +155,7 @@ describe('FormAnswerPreviewPanel', () => {
     expect(wrapper.text()).toContain('机, 椅子')
     expect(wrapper.text()).toContain('複数行\nテキスト')
     expect(wrapper.text()).toContain('山田太郎')
+    expect(wrapper.html()).toContain('<strong>太字</strong>')
     expect(wrapper.text()).toContain('layout.pdf')
     expect(wrapper.text()).toContain('1 件')
     expect(wrapper.get('a[href="/download/form-1/upload-1"]').text()).toContain('ダウンロード')

--- a/frontend/src/components/staff/forms/FormAnswerPreviewPanel.vue
+++ b/frontend/src/components/staff/forms/FormAnswerPreviewPanel.vue
@@ -5,6 +5,7 @@ import { formatDateTime } from '@/lib/format/datetime'
 import SurfaceCardBand from '@/components/ui/SurfaceCardBand.vue'
 import UploadFileRow from './UploadFileRow.vue'
 import SurfaceCard from '@/components/ui/SurfaceCard.vue'
+import PageMarkdownContent from '@/features/pages/components/PageMarkdownContent.vue'
 
 const { formId, form, isParticipationForm } = defineProps<{
   formId: string
@@ -80,6 +81,12 @@ const totalUploads = computed(() => form.answer?.uploads.length ?? 0)
           <pre v-else-if="question.type === 'textarea'" class="mt-3 whitespace-pre-wrap text-sm leading-7 text-body">{{
             answerDetails(question.id)[0] ?? ''
           }}</pre>
+
+          <PageMarkdownContent
+            v-else-if="question.type === 'markdown'"
+            class="mt-3 rounded border border-border bg-surface-light p-3"
+            :source="answerDetails(question.id)[0] ?? ''"
+          />
 
           <p v-else class="mt-3 text-sm leading-7 text-body">
             {{ answerDetails(question.id)[0] ?? '未入力' }}

--- a/frontend/src/components/staff/forms/FormAnswerPreviewPanel.vue
+++ b/frontend/src/components/staff/forms/FormAnswerPreviewPanel.vue
@@ -84,7 +84,7 @@ const totalUploads = computed(() => form.answer?.uploads.length ?? 0)
 
           <PageMarkdownContent
             v-else-if="question.type === 'markdown'"
-            class="mt-3 rounded border border-border bg-surface-light p-3"
+            class="mt-3 rounded border border-border bg-surface p-3"
             :source="answerDetails(question.id)[0] ?? ''"
           />
 

--- a/frontend/src/components/staff/forms/editor/FormQuestionPreviewItem.stories.ts
+++ b/frontend/src/components/staff/forms/editor/FormQuestionPreviewItem.stories.ts
@@ -64,6 +64,48 @@ export const Textarea: Story = {
   }
 }
 
+export const Markdown: Story = {
+  args: {
+    question: {
+      ...baseQuestion,
+      id: 'q-markdown',
+      type: 'markdown',
+      name: '企画紹介文',
+      description: '## 見どころ\n\n- 体験できます\n- 写真撮影できます'
+    },
+    edit: {
+      ...baseQuestion,
+      id: 'q-markdown',
+      type: 'markdown',
+      name: '企画紹介文',
+      description: '## 見どころ\n\n- 体験できます\n- 写真撮影できます'
+    },
+    isOpen: false
+  }
+}
+
+export const NumberSelect: Story = {
+  args: {
+    question: {
+      ...baseQuestion,
+      id: 'q-number',
+      name: '参加人数',
+      type: 'number',
+      numberMin: 1,
+      numberMax: 8
+    },
+    edit: {
+      ...baseQuestion,
+      id: 'q-number',
+      name: '参加人数',
+      type: 'number',
+      numberMin: 1,
+      numberMax: 8
+    },
+    isOpen: false
+  }
+}
+
 export const Radio: Story = {
   args: {
     question: {

--- a/frontend/src/components/staff/forms/editor/FormQuestionPreviewItem.vue
+++ b/frontend/src/components/staff/forms/editor/FormQuestionPreviewItem.vue
@@ -6,7 +6,9 @@ import { inputValue, textareaValue } from '@/lib/dom'
 import { normalizeOptions } from '@/lib/parseOptions'
 import PreviewHeading from './previews/PreviewHeading.vue'
 import PreviewText from './previews/PreviewText.vue'
+import PreviewNumber from './previews/PreviewNumber.vue'
 import PreviewTextarea from './previews/PreviewTextarea.vue'
+import PreviewMarkdown from './previews/PreviewMarkdown.vue'
 import PreviewRadio from './previews/PreviewRadio.vue'
 import PreviewSelect from './previews/PreviewSelect.vue'
 import PreviewCheckbox from './previews/PreviewCheckbox.vue'
@@ -127,11 +129,11 @@ const parsedOptions = computed(() => [...new Set(edit.options.filter((item) => i
 const showRequired = computed(() => edit.type !== 'heading')
 const showOptions = computed(() => ['radio', 'select', 'checkbox'].includes(edit.type))
 const showAllowedTypes = computed(() => edit.type === 'upload')
-const showNumberMin = computed(() => ['text', 'number', 'checkbox'].includes(edit.type))
-const showNumberMax = computed(() => ['text', 'number', 'checkbox'].includes(edit.type))
+const showNumberMin = computed(() => ['text', 'textarea', 'markdown', 'number', 'checkbox'].includes(edit.type))
+const showNumberMax = computed(() => ['text', 'textarea', 'markdown', 'number', 'checkbox'].includes(edit.type))
 const nameLabel = computed(() => (edit.type === 'heading' ? '見出し' : '設問名'))
 const numberMinLabel = computed(() => {
-  if (edit.type === 'text') {
+  if (['text', 'textarea', 'markdown'].includes(edit.type)) {
     return '最小文字数'
   }
   if (edit.type === 'number') {
@@ -143,7 +145,7 @@ const numberMinLabel = computed(() => {
   return null
 })
 const numberMaxLabel = computed(() => {
-  if (edit.type === 'text') {
+  if (['text', 'textarea', 'markdown'].includes(edit.type)) {
     return '最大文字数'
   }
   if (edit.type === 'number') {
@@ -160,10 +162,13 @@ const previewComponent = computed<Component>(() => {
     case 'heading':
       return PreviewHeading
     case 'text':
-    case 'number':
       return PreviewText
+    case 'number':
+      return PreviewNumber
     case 'textarea':
       return PreviewTextarea
+    case 'markdown':
+      return PreviewMarkdown
     case 'radio':
       return PreviewRadio
     case 'select':
@@ -186,9 +191,11 @@ const previewProps = computed<Record<string, unknown>>(() => {
     case 'heading':
       return base
     case 'text':
-    case 'number':
       return { ...base, isRequired: edit.isRequired, type: edit.type }
+    case 'number':
+      return { ...base, isRequired: edit.isRequired, numberMin: edit.numberMin, numberMax: edit.numberMax }
     case 'textarea':
+    case 'markdown':
       return { ...base, isRequired: edit.isRequired }
     case 'radio':
     case 'select':

--- a/frontend/src/components/staff/forms/editor/previews/PreviewMarkdown.vue
+++ b/frontend/src/components/staff/forms/editor/previews/PreviewMarkdown.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import PageMarkdownContent from '@/features/pages/components/PageMarkdownContent.vue'
+
+defineProps<{
+  name: string
+  description: string
+  isRequired: boolean
+}>()
+</script>
+
+<template>
+  <div class="mb-2 flex items-center gap-2">
+    <span class="font-medium text-body">{{ name || '(無題の設問)' }}</span>
+    <span v-if="isRequired" class="rounded bg-danger px-1.5 py-0.5 text-xs font-bold text-white">必須</span>
+  </div>
+  <PageMarkdownContent v-if="description" class="mb-2" :source="description" />
+  <div class="rounded border border-border bg-form-control px-3 py-3 text-sm text-muted">Markdown 入力</div>
+</template>

--- a/frontend/src/components/staff/forms/editor/previews/PreviewNumber.vue
+++ b/frontend/src/components/staff/forms/editor/previews/PreviewNumber.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const { numberMin, numberMax } = defineProps<{
+  name: string
+  description: string
+  isRequired: boolean
+  numberMin: number | null
+  numberMax: number | null
+}>()
+
+const numberOptions = computed(() => {
+  if (numberMin === null || numberMax === null || numberMin > numberMax) {
+    return []
+  }
+
+  return Array.from({ length: numberMax - numberMin + 1 }, (_, index) => numberMin + index)
+})
+</script>
+
+<template>
+  <div class="mb-2 flex items-center gap-2">
+    <span class="font-medium text-body">{{ name || '(無題の設問)' }}</span>
+    <span v-if="isRequired" class="rounded bg-danger px-1.5 py-0.5 text-xs font-bold text-white">必須</span>
+  </div>
+  <p v-if="description" class="mb-2 whitespace-pre-wrap text-sm leading-7 text-muted">
+    {{ description }}
+  </p>
+  <select
+    :aria-label="`${name || '整数入力'}のプレビュー`"
+    class="w-full rounded border border-border bg-form-control px-3 py-2 text-sm text-muted"
+    disabled
+    tabindex="-1"
+  >
+    <option v-if="numberOptions.length === 0">最低数・最大数を設定してください</option>
+    <option v-for="option in numberOptions" :key="option" :value="option">{{ option }}</option>
+  </select>
+</template>

--- a/frontend/src/components/staff/forms/editor/previews/PreviewNumber.vue
+++ b/frontend/src/components/staff/forms/editor/previews/PreviewNumber.vue
@@ -9,12 +9,17 @@ const { numberMin, numberMax } = defineProps<{
   numberMax: number | null
 }>()
 
+const MAX_NUMBER_SELECT_OPTIONS = 200
+
 const numberOptions = computed(() => {
   if (numberMin === null || numberMax === null || numberMin > numberMax) {
-    return []
+    return null
   }
-
-  return Array.from({ length: numberMax - numberMin + 1 }, (_, index) => numberMin + index)
+  const count = numberMax - numberMin + 1
+  if (count > MAX_NUMBER_SELECT_OPTIONS) {
+    return null
+  }
+  return Array.from({ length: count }, (_, index) => numberMin + index)
 })
 </script>
 
@@ -27,12 +32,20 @@ const numberOptions = computed(() => {
     {{ description }}
   </p>
   <select
+    v-if="numberOptions !== null"
     :aria-label="`${name || '整数入力'}のプレビュー`"
     class="w-full rounded border border-border bg-form-control px-3 py-2 text-sm text-muted"
     disabled
     tabindex="-1"
   >
-    <option v-if="numberOptions.length === 0">最低数・最大数を設定してください</option>
     <option v-for="option in numberOptions" :key="option" :value="option">{{ option }}</option>
   </select>
+  <p
+    v-else-if="numberMin !== null && numberMax !== null && numberMax - numberMin + 1 > MAX_NUMBER_SELECT_OPTIONS"
+    class="text-xs text-muted"
+  >
+    選択肢数（{{ numberMax - numberMin + 1 }} 件）が上限（{{ MAX_NUMBER_SELECT_OPTIONS }}
+    件）を超えています。最低数・最大数の範囲を狭めてください。
+  </p>
+  <p v-else class="text-xs text-muted">最低数・最大数を設定してください</p>
 </template>

--- a/frontend/src/components/ui/BottomTabLink.test.ts
+++ b/frontend/src/components/ui/BottomTabLink.test.ts
@@ -4,6 +4,12 @@ import BottomTabLink from './BottomTabLink.vue'
 
 describe('BottomTabLink', () => {
   it('renders label, icon, and notifier', () => {
+    const FaIconStub = {
+      name: 'FaIcon',
+      props: ['name', 'prefix', 'fixedWidth', 'pulse', 'className', 'iconClass'],
+      template: '<span />'
+    }
+
     const wrapper = mount(BottomTabLink, {
       props: {
         to: '/workspace',
@@ -14,14 +20,19 @@ describe('BottomTabLink', () => {
       },
       global: {
         stubs: {
-          RouterLink: RouterLinkStub
+          RouterLink: RouterLinkStub,
+          FaIcon: FaIconStub
         }
       }
     })
 
     expect(wrapper.getComponent(RouterLinkStub).props('to')).toBe('/workspace')
     expect(wrapper.text()).toContain('ホーム')
-    expect(wrapper.find('i.fas.fa-home').exists()).toBe(true)
-    expect(wrapper.find('i.fas.fa-circle').exists()).toBe(true)
+
+    const faIcons = wrapper.findAllComponents(FaIconStub)
+    const iconFaIcon = faIcons.find((w) => w.props('iconClass') === 'fas fa-home')
+    expect(iconFaIcon?.exists()).toBe(true)
+    const notifierFaIcon = faIcons.find((w) => w.props('name') === 'circle')
+    expect(notifierFaIcon?.exists()).toBe(true)
   })
 })

--- a/frontend/src/components/ui/CsvExportLink.vue
+++ b/frontend/src/components/ui/CsvExportLink.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import FaIcon from '@/components/ui/FaIcon.vue'
+
 const { href, download } = defineProps<{
   href: string
   download?: boolean

--- a/frontend/src/components/ui/NavMenuLink.test.ts
+++ b/frontend/src/components/ui/NavMenuLink.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { mount, RouterLinkStub } from '@vue/test-utils'
 import NavMenuLink from './NavMenuLink.vue'
 
+const FaIconStub = {
+  name: 'FaIcon',
+  props: ['name', 'prefix', 'fixedWidth', 'pulse', 'className', 'iconClass'],
+  template: '<span />'
+}
+
 describe('NavMenuLink', () => {
   it('renders label and icon', () => {
     const wrapper = mount(NavMenuLink, {
@@ -12,14 +18,17 @@ describe('NavMenuLink', () => {
       },
       global: {
         stubs: {
-          RouterLink: RouterLinkStub
+          RouterLink: RouterLinkStub,
+          FaIcon: FaIconStub
         }
       }
     })
 
     expect(wrapper.getComponent(RouterLinkStub).props('to')).toBe('/staff')
     expect(wrapper.text()).toContain('スタッフ')
-    expect(wrapper.find('i.fas.fa-user').exists()).toBe(true)
+    const faIcon = wrapper.findComponent(FaIconStub)
+    expect(faIcon.exists()).toBe(true)
+    expect(faIcon.props('iconClass')).toBe('fas fa-user')
   })
 
   it('shows active indicator when active', () => {
@@ -31,7 +40,8 @@ describe('NavMenuLink', () => {
       },
       global: {
         stubs: {
-          RouterLink: RouterLinkStub
+          RouterLink: RouterLinkStub,
+          FaIcon: FaIconStub
         }
       }
     })

--- a/frontend/src/features/contact/api.ts
+++ b/frontend/src/features/contact/api.ts
@@ -22,6 +22,7 @@ interface SubmitContactPayload {
   categoryId: string
   subject: string
   body: string
+  ccSubleader?: boolean
 }
 
 type SubmitContactResult = ContactSubmission

--- a/frontend/src/features/public-home/components/PublicPageDetailContent.vue
+++ b/frontend/src/features/public-home/components/PublicPageDetailContent.vue
@@ -40,7 +40,7 @@ const page = pageQuery.data
       </div>
     </section>
 
-    <div class="py-2">
+    <div class="rounded bg-surface px-6 py-8 shadow-lv1">
       <PageMarkdownContent :source="page.body" />
     </div>
 

--- a/frontend/src/features/staff/forms/api.ts
+++ b/frontend/src/features/staff/forms/api.ts
@@ -21,6 +21,7 @@ export const allowedQuestionTypes = [
   'heading',
   'text',
   'textarea',
+  'markdown',
   'number',
   'radio',
   'select',

--- a/frontend/src/features/staff/forms/editor/useQuestionTypeMeta.ts
+++ b/frontend/src/features/staff/forms/editor/useQuestionTypeMeta.ts
@@ -12,6 +12,7 @@ export const QUESTION_TYPE_META: Record<AllowedQuestionType, QuestionTypeMeta> =
   text: { label: '一行入力', icon: '≡' },
   number: { label: '整数入力', icon: '#' },
   textarea: { label: '複数行入力', icon: '☰' },
+  markdown: { label: 'Markdown 入力', icon: 'M' },
   radio: { label: '単一選択（ラジオボタン）', icon: '◉' },
   select: { label: '単一選択（ドロップダウン）', icon: '▼' },
   checkbox: { label: '複数選択（チェックボックス）', icon: '☑' },

--- a/frontend/src/lib/api/schema.ts
+++ b/frontend/src/lib/api/schema.ts
@@ -4,6 +4,7 @@ export const formQuestionTypeSchema = z.enum([
   'heading',
   'text',
   'textarea',
+  'markdown',
   'number',
   'radio',
   'select',

--- a/frontend/src/lib/form-validation/schemas.test.ts
+++ b/frontend/src/lib/form-validation/schemas.test.ts
@@ -8,7 +8,8 @@ import {
   hiraganaSchema,
   requiredTextSchema,
   userRegistrationFormSchema,
-  circleRegistrationFormSchema
+  circleRegistrationFormSchema,
+  buildFormAnswerSchema
 } from './schemas'
 
 describe('passwordSchema', () => {
@@ -39,6 +40,41 @@ describe('passwordSchema', () => {
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0].message).toContain('数字')
+    }
+  })
+})
+
+describe('buildFormAnswerSchema', () => {
+  it('validates markdown required and max length rules', () => {
+    const schema = buildFormAnswerSchema([
+      {
+        id: 'question-markdown',
+        name: 'Markdown設問',
+        description: '',
+        type: 'markdown',
+        isRequired: true,
+        numberMin: null,
+        numberMax: 5,
+        allowedTypes: '',
+        options: [],
+        priority: 1,
+        createdAt: '2026-03-01T00:00:00Z',
+        updatedAt: '2026-03-01T00:00:00Z'
+      }
+    ])
+
+    expect(schema.safeParse({ 'question-markdown': '**OK' }).success).toBe(true)
+
+    const emptyResult = schema.safeParse({ 'question-markdown': '' })
+    expect(emptyResult.success).toBe(false)
+    if (!emptyResult.success) {
+      expect(emptyResult.error.issues[0].message).toContain('Markdown設問を入力してください')
+    }
+
+    const longResult = schema.safeParse({ 'question-markdown': '123456' })
+    expect(longResult.success).toBe(false)
+    if (!longResult.success) {
+      expect(longResult.error.issues[0].message).toContain('5文字以下')
     }
   })
 })

--- a/frontend/src/lib/form-validation/schemas.ts
+++ b/frontend/src/lib/form-validation/schemas.ts
@@ -108,6 +108,7 @@ export type PasswordChangeFormData = z.infer<typeof passwordChangeFormSchema>
  */
 export const contactFormSchema = z.object({
   categoryId: z.string().min(1, 'お問い合わせ項目を選択してください'),
+  ccSubleader: z.boolean(),
   body: z.string().min(1, 'お問い合わせ内容を入力してください')
 })
 
@@ -296,10 +297,26 @@ export function buildFormAnswerSchema(questions: FormQuestion[]) {
               const base = z.array(z.string())
               return question.isRequired ? base.min(1, `${question.name}を選択してください`) : base
             })()
-          : // Text, textarea, select, radio
-            question.isRequired
-            ? z.string().min(1, `${question.name}を入力してください`)
-            : z.string()
+          : ['text', 'textarea', 'markdown'].includes(question.type)
+            ? z.string().superRefine((val, ctx) => {
+                if (val === '' && !question.isRequired) {
+                  return
+                }
+                if (val === '') {
+                  ctx.addIssue({ code: 'custom', message: `${question.name}を入力してください` })
+                  return
+                }
+                if (question.numberMin !== null && Array.from(val).length < question.numberMin) {
+                  ctx.addIssue({ code: 'custom', message: `${question.numberMin}文字以上で入力してください` })
+                }
+                if (question.numberMax !== null && Array.from(val).length > question.numberMax) {
+                  ctx.addIssue({ code: 'custom', message: `${question.numberMax}文字以下で入力してください` })
+                }
+              })
+            : // Select, radio
+              question.isRequired
+              ? z.string().min(1, `${question.name}を入力してください`)
+              : z.string()
 
     shape[question.id] = fieldSchema
   }

--- a/frontend/src/pages/circles/select.test.ts
+++ b/frontend/src/pages/circles/select.test.ts
@@ -115,6 +115,7 @@ describe('CircleSelectorPage', () => {
       history: createMemoryHistory(),
       routes: [
         { path: '/circles/select', component: CircleSelectorPage },
+        { path: '/circles/new', component: { template: '<div>new</div>' } },
         { path: '/', component: { template: '<div>home</div>' } }
       ]
     })
@@ -170,6 +171,7 @@ describe('CircleSelectorPage', () => {
       history: createMemoryHistory(),
       routes: [
         { path: '/circles/select', component: CircleSelectorPage },
+        { path: '/circles/new', component: { template: '<div>new</div>' } },
         { path: '/workspace/forms/:formId', component: { template: '<div>form</div>' } }
       ]
     })
@@ -226,6 +228,7 @@ describe('CircleSelectorPage', () => {
       history: createMemoryHistory(),
       routes: [
         { path: '/circles/select', component: CircleSelectorPage },
+        { path: '/circles/new', component: { template: '<div>new</div>' } },
         { path: '/workspace/forms/:formId', component: { template: '<div>form</div>' } }
       ]
     })
@@ -261,7 +264,10 @@ describe('CircleSelectorPage', () => {
 
     const router = createRouter({
       history: createMemoryHistory(),
-      routes: [{ path: '/circles/select', component: CircleSelectorPage }]
+      routes: [
+        { path: '/circles/select', component: CircleSelectorPage },
+        { path: '/circles/new', component: { template: '<div>new</div>' } }
+      ]
     })
     await router.push('/circles/select')
     await router.isReady()

--- a/frontend/src/pages/email/verify/[type]/[userId].test.ts
+++ b/frontend/src/pages/email/verify/[type]/[userId].test.ts
@@ -17,7 +17,8 @@ async function mountAtVerifyAction() {
       { path: '/', component: { template: '<div>home</div>' } },
       { path: '/login', component: { template: '<div>login</div>' } },
       { path: '/email/verify/completed', component: EmailVerifyCompletedPage },
-      { path: '/email/verify/:type/:userId', component: EmailVerifyActionPage }
+      { path: '/email/verify/:type/:userId', component: EmailVerifyActionPage },
+      { path: '/email/verify', component: { template: '<div>verify</div>' } }
     ]
   })
 
@@ -190,7 +191,8 @@ describe('EmailVerifyActionPage', () => {
         { path: '/', component: { template: '<div>home</div>' } },
         { path: '/login', component: { template: '<div>login</div>' } },
         { path: '/email/verify/completed', component: EmailVerifyCompletedPage },
-        { path: '/email/verify/:type/:userId', component: EmailVerifyActionPage }
+        { path: '/email/verify/:type/:userId', component: EmailVerifyActionPage },
+        { path: '/email/verify', component: { template: '<div>verify</div>' } }
       ]
     })
 

--- a/frontend/src/pages/staff/forms/[formId]/edit.vue
+++ b/frontend/src/pages/staff/forms/[formId]/edit.vue
@@ -68,7 +68,7 @@ const { getFieldError, validateAll, markTouched } = useFormValidation({
   form: editForm
 })
 
-const staffFormTabs = computed(() => buildStaffFormTabs(formId.value, 'edit'))
+const staffFormTabs = computed(() => (formId.value.length > 0 ? buildStaffFormTabs(formId.value, 'edit') : []))
 const isParticipationForm = computed(() => formQuery.data.value?.isParticipationForm ?? false)
 const availableTags = computed(() => (tagsQuery.data.value ?? []).map((tag) => tag.name))
 

--- a/frontend/src/pages/staff/forms/[formId]/preview.vue
+++ b/frontend/src/pages/staff/forms/[formId]/preview.vue
@@ -97,14 +97,19 @@ function handleUploadChange(question: StaffFormQuestion, event: Event) {
   submitNoticeVisible.value = false
 }
 
-function questionNumberOptions(question: StaffFormQuestion) {
+const MAX_NUMBER_SELECT_OPTIONS = 200
+
+function questionNumberOptions(question: StaffFormQuestion): number[] | null {
   const min = question.numberMin
   const max = question.numberMax
   if (min === null || max === null || min > max) {
-    return []
+    return null
   }
-
-  return Array.from({ length: max - min + 1 }, (_, index) => min + index)
+  const count = max - min + 1
+  if (count > MAX_NUMBER_SELECT_OPTIONS) {
+    return null
+  }
+  return Array.from({ length: count }, (_, index) => min + index)
 }
 
 function handlePreviewSubmit() {
@@ -203,16 +208,25 @@ function handlePreviewSubmit() {
                   @update:model-value="updateQuestionValue(question.id, $event)"
                 />
                 <select
-                  v-else-if="question.type === 'number'"
+                  v-else-if="question.type === 'number' && questionNumberOptions(question) !== null"
                   class="rounded border border-border bg-form-control px-4 py-3 text-sm text-body"
                   :value="questionValue(question.id)"
                   @change="updateQuestionValue(question.id, selectValue($event))"
                 >
                   <option value="">選択してください</option>
-                  <option v-for="option in questionNumberOptions(question)" :key="option" :value="String(option)">
+                  <option v-for="option in questionNumberOptions(question)!" :key="option" :value="String(option)">
                     {{ option }}
                   </option>
                 </select>
+                <input
+                  v-else-if="question.type === 'number'"
+                  class="rounded border border-border bg-form-control px-4 py-3 text-sm text-body"
+                  :value="questionValue(question.id)"
+                  type="number"
+                  :min="question.numberMin ?? undefined"
+                  :max="question.numberMax ?? undefined"
+                  @input="updateQuestionValue(question.id, inputValue($event))"
+                />
                 <select
                   v-else-if="question.type === 'select'"
                   class="rounded border border-border bg-form-control px-4 py-3 text-sm text-body"

--- a/frontend/src/pages/staff/forms/[formId]/preview.vue
+++ b/frontend/src/pages/staff/forms/[formId]/preview.vue
@@ -18,6 +18,7 @@ import LoadingState from '@/components/ui/LoadingState.vue'
 import ErrorState from '@/components/ui/ErrorState.vue'
 import BaseButton from '@/components/ui/BaseButton.vue'
 import ActionsFooter from '@/components/ui/ActionsFooter.vue'
+import MarkdownEditorField from '@/components/ui/MarkdownEditorField.vue'
 import { inputChecked, inputValue, selectValue, textareaValue } from '@/lib/dom'
 
 const route = useRoute('/staff/forms/[formId]/preview')
@@ -94,6 +95,16 @@ function handleUploadChange(question: StaffFormQuestion, event: Event) {
     [question.id]: target.files?.[0]?.name ?? ''
   }
   submitNoticeVisible.value = false
+}
+
+function questionNumberOptions(question: StaffFormQuestion) {
+  const min = question.numberMin
+  const max = question.numberMax
+  if (min === null || max === null || min > max) {
+    return []
+  }
+
+  return Array.from({ length: max - min + 1 }, (_, index) => min + index)
 }
 
 function handlePreviewSubmit() {
@@ -184,14 +195,24 @@ function handlePreviewSubmit() {
                   placeholder="複数行入力"
                   @input="updateQuestionValue(question.id, textareaValue($event))"
                 />
-                <input
+                <MarkdownEditorField
+                  v-else-if="question.type === 'markdown'"
+                  :model-value="questionValue(question.id)"
+                  :name="question.id"
+                  min-height-class="min-h-32"
+                  @update:model-value="updateQuestionValue(question.id, $event)"
+                />
+                <select
                   v-else-if="question.type === 'number'"
                   class="rounded border border-border bg-form-control px-4 py-3 text-sm text-body"
-                  type="number"
                   :value="questionValue(question.id)"
-                  placeholder="整数入力"
-                  @input="updateQuestionValue(question.id, inputValue($event))"
-                />
+                  @change="updateQuestionValue(question.id, selectValue($event))"
+                >
+                  <option value="">選択してください</option>
+                  <option v-for="option in questionNumberOptions(question)" :key="option" :value="String(option)">
+                    {{ option }}
+                  </option>
+                </select>
                 <select
                   v-else-if="question.type === 'select'"
                   class="rounded border border-border bg-form-control px-4 py-3 text-sm text-body"

--- a/frontend/src/pages/staff/index.test.ts
+++ b/frontend/src/pages/staff/index.test.ts
@@ -55,6 +55,7 @@ describe('StaffDashboardPage', () => {
     const router = createRouter({
       history: createMemoryHistory(),
       routes: [
+        { path: '/', component: { template: '<div>home</div>' } },
         { path: '/staff', component: StaffDashboardPage },
         { path: '/staff/circles', component: { template: '<div>staff circles</div>' } },
         {
@@ -138,12 +139,37 @@ describe('StaffDashboardPage', () => {
     const router = createRouter({
       history: createMemoryHistory(),
       routes: [
+        { path: '/', component: { template: '<div>home</div>' } },
         { path: '/staff', component: StaffDashboardPage },
         { path: '/staff/circles', component: { template: '<div>staff circles</div>' } },
         {
           path: '/staff/circles/participation_types',
           component: { template: '<div>participation types</div>' }
         },
+        {
+          path: '/staff/activity-logs',
+          component: { template: '<div>activity logs</div>' }
+        },
+        { path: '/staff/pages', component: { template: '<div>staff pages</div>' } },
+        { path: '/staff/mails', component: { template: '<div>staff mails</div>' } },
+        { path: '/staff/documents', component: { template: '<div>staff documents</div>' } },
+        { path: '/staff/tags', component: { template: '<div>staff tags</div>' } },
+        { path: '/staff/places', component: { template: '<div>staff places</div>' } },
+        {
+          path: '/staff/contact-categories',
+          component: { template: '<div>staff contact categories</div>' }
+        },
+        { path: '/staff/forms', component: { template: '<div>staff forms</div>' } },
+        { path: '/staff/settings', component: { template: '<div>staff settings</div>' } },
+        {
+          path: '/staff/markdown-guide',
+          component: { template: '<div>staff markdown guide</div>' }
+        },
+        {
+          path: '/staff/permissions',
+          component: { template: '<div>staff permissions</div>' }
+        },
+        { path: '/staff/users', component: { template: '<div>staff users</div>' } },
         { path: '/staff/exports', component: { template: '<div>exports</div>' } }
       ]
     })

--- a/frontend/src/pages/staff/markdown-guide.vue
+++ b/frontend/src/pages/staff/markdown-guide.vue
@@ -54,7 +54,7 @@ const guideSections = [
         >
           <h3 class="text-base font-semibold text-body">{{ section.title }}</h3>
           <pre
-            class="mt-3 overflow-x-auto whitespace-pre-wrap rounded bg-background px-4 py-3 text-sm leading-7 text-body"
+            class="mt-3 overflow-x-auto whitespace-pre-wrap rounded bg-surface px-4 py-3 text-sm leading-7 text-body"
           ><code>{{ section.example }}</code></pre>
         </article>
       </div>

--- a/frontend/src/pages/workspace/circles/confirm.vue
+++ b/frontend/src/pages/workspace/circles/confirm.vue
@@ -10,6 +10,7 @@ definePage({
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import AlertMessage from '@/components/ui/AlertMessage.vue'
+import PageMarkdownContent from '@/features/pages/components/PageMarkdownContent.vue'
 import SurfaceCard from '@/components/ui/SurfaceCard.vue'
 import SurfaceCardBand from '@/components/ui/SurfaceCardBand.vue'
 import PageLayout from '@/components/layouts/PageLayout.vue'
@@ -139,6 +140,11 @@ function uploadNames(questionId: string) {
                 <li v-for="name in uploadNames(question.id)" :key="name">{{ name }}</li>
                 <li v-if="uploadNames(question.id).length === 0" class="list-none text-muted">未アップロード</li>
               </ul>
+              <PageMarkdownContent
+                v-else-if="question.type === 'markdown'"
+                class="mt-3 rounded border border-border bg-surface-light p-3"
+                :source="answerText(question.id)"
+              />
               <p v-else class="mt-3 whitespace-pre-wrap text-sm text-body">
                 {{ answerText(question.id) }}
               </p>

--- a/frontend/src/pages/workspace/circles/confirm.vue
+++ b/frontend/src/pages/workspace/circles/confirm.vue
@@ -142,7 +142,7 @@ function uploadNames(questionId: string) {
               </ul>
               <PageMarkdownContent
                 v-else-if="question.type === 'markdown'"
-                class="mt-3 rounded border border-border bg-surface-light p-3"
+                class="mt-3 rounded border border-border bg-surface p-3"
                 :source="answerText(question.id)"
               />
               <p v-else class="mt-3 whitespace-pre-wrap text-sm text-body">

--- a/frontend/src/pages/workspace/contact.stories.ts
+++ b/frontend/src/pages/workspace/contact.stories.ts
@@ -18,7 +18,19 @@ const meta = {
           })
         ),
         http.get('/v1/contact-categories', () => HttpResponse.json([mockContactCategory])),
-        http.post('/v1/contact', () => new HttpResponse(null, { status: 204 }))
+        http.post('/v1/contact', () =>
+          HttpResponse.json(
+            {
+              id: 'contact-job-1',
+              categoryId: mockContactCategory.id,
+              categoryName: mockContactCategory.name,
+              subject: mockContactCategory.name,
+              status: 'queued',
+              createdAt: '2026-03-13T10:00:00Z'
+            },
+            { status: 201 }
+          )
+        )
       ]
     }
   }

--- a/frontend/src/pages/workspace/contact.test.ts
+++ b/frontend/src/pages/workspace/contact.test.ts
@@ -67,6 +67,7 @@ async function fillContactForm(wrapper: ReturnType<typeof mount>) {
 
 describe('ContactPage', () => {
   it('lists categories and submits a contact message', async () => {
+    let submittedBody: unknown
     server.use(
       http.get('/v1/contact-categories', () =>
         HttpResponse.json([
@@ -74,8 +75,9 @@ describe('ContactPage', () => {
           { id: 'contact-other', name: 'その他' }
         ])
       ),
-      http.post('/v1/contact', () =>
-        HttpResponse.json(
+      http.post('/v1/contact', async ({ request }) => {
+        submittedBody = await request.json()
+        return HttpResponse.json(
           {
             id: 'mail-job-1',
             categoryId: 'contact-other',
@@ -86,7 +88,7 @@ describe('ContactPage', () => {
           },
           { status: 201 }
         )
-      )
+      })
     )
 
     const { router, wrapper } = await mountContactPage()
@@ -96,6 +98,7 @@ describe('ContactPage', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('「その他」に問い合わせを送信しました。')
+    expect(submittedBody).toMatchObject({ categoryId: 'contact-other', ccSubleader: true })
     expect(wrapper.get('a[href="/workspace/settings"]').text()).toContain('ユーザー設定')
     expect(wrapper.find('input[readonly]').exists()).toBe(false)
     expect(router.currentRoute.value.fullPath).toBe('/workspace/contact')

--- a/frontend/src/pages/workspace/contact.vue
+++ b/frontend/src/pages/workspace/contact.vue
@@ -29,6 +29,7 @@ const categoriesQuery = useContactCategoriesQuery()
 const submitContactMutation = useSubmitContactMutation()
 const form = reactive({
   categoryId: '',
+  ccSubleader: true,
   body: ''
 })
 const submitErrorMessage = ref('')
@@ -54,10 +55,12 @@ async function handleSubmit() {
     const result = await submitContactMutation.mutateAsync({
       categoryId: form.categoryId,
       subject: selectedCategoryName.value || 'お問い合わせ',
-      body: form.body
+      body: form.body,
+      ccSubleader: form.ccSubleader
     })
     successMessage.value = `「${result.categoryName}」に問い合わせを送信しました。`
     form.categoryId = ''
+    form.ccSubleader = true
     form.body = ''
   } catch (error) {
     submitErrorMessage.value = extractContactValidationMessage(error)
@@ -93,6 +96,22 @@ async function handleSubmit() {
             </select>
           </FormField>
           <FormError v-if="getFieldError('categoryId')" :message="getFieldError('categoryId')" />
+        </div>
+
+        <div v-if="sessionStore.currentCircle" class="grid gap-2">
+          <FormField label="返信内容の共有先">
+            <label
+              class="flex items-start gap-3 rounded border border-border bg-surface-light px-4 py-3 text-sm text-body"
+            >
+              <input v-model="form.ccSubleader" class="mt-1" name="ccSubleader" type="checkbox" />
+              <span>
+                <span class="block font-medium">副責任者にもメールで共有する（CC）</span>
+                <span class="mt-1 block text-xs leading-6 text-muted-2">
+                  チェックを外すと送信者のみに確認メールが送信されます。
+                </span>
+              </span>
+            </label>
+          </FormField>
         </div>
 
         <div class="grid gap-2">

--- a/frontend/tests/e2e/integration/requirements.spec.ts
+++ b/frontend/tests/e2e/integration/requirements.spec.ts
@@ -286,7 +286,7 @@ test('workspace form covers question types, uploads, staff answer verification, 
 
   await page.getByLabel('E2E テキスト').fill('テキスト回答')
   await page.getByLabel('E2E 長文').fill('長文回答')
-  await page.getByLabel('E2E 数値').fill('7')
+  await page.getByLabel('E2E 数値').selectOption('7')
   await page.getByLabel('E2E セレクト').selectOption('セレクトB')
   await page.getByLabel('ラジオA').check()
   await page.getByLabel('チェックA').check()

--- a/frontend/tests/e2e/integration/utils.ts
+++ b/frontend/tests/e2e/integration/utils.ts
@@ -439,12 +439,9 @@ export async function waitForMiniflareEmail(
     before = new Set<string>()
   }: { timeoutMs?: number; intervalMs?: number; before?: Set<string> } = {}
 ): Promise<string> {
-  const dirs = findMiniflareEmailTextDirs()
-  if (dirs.length === 0) {
-    throw new Error('miniflare email-text directory not found. Run `mise run dev:worker` to start the email worker.')
-  }
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
+    const dirs = findMiniflareEmailTextDirs()
     for (const filePath of listEmailFiles(dirs)) {
       if (before.has(filePath)) {
         continue
@@ -460,5 +457,7 @@ export async function waitForMiniflareEmail(
     }
     await new Promise((resolve) => setTimeout(resolve, intervalMs))
   }
-  throw new Error('Timed out waiting for matching miniflare email file')
+  throw new Error(
+    'Timed out waiting for matching miniflare email file. Run `mise run dev:worker` to start the email worker.'
+  )
 }


### PR DESCRIPTION
## 概要

s-union/6.x ブランチの機能を Go バックエンド + Vue フロントエンド構成に移植したPRです。

---

## バックエンド

### `markdown` 設問タイプの追加

- `formquestion/repository.go` — `AllowedQuestionTypes` に `"markdown"` を追加
- `formquestion/validation.go` — `text`/`textarea` と同様に `markdown` にも `NumberMin`/`NumberMax` による文字数バリデーションを適用
- `form_answer_helpers_test.go` — markdown の文字数上限バリデーションのテストケースを追加

### お問い合わせ（Contact）副責任者CC制御

- `openapi.yaml` — `POST /v1/contact` リクエストボディに `ccSubleader: boolean`（デフォルト `true`）を追加
- `contact_profile.go`
  - `contactConfirmationRecipients` に `ccSubleader bool` 引数を追加
  - `contactShouldCCSubleader` — `nil` の場合は `true`（既存の全員CC動作を維持）
  - `contactCircleConfirmationRecipients` — リーダー/副責任者を分類し、`ccSubleader=false` のときは送信者本人のみに確認メールを送る
- `contact_profile_test.go` — 副責任者CC・送信者のみ・リーダーのみの3パターンと、デフォルト値のテストを追加

### `.air.toml` 設定更新

- `bin`/`full_bin` → `entrypoint` に変更（air v1.61+ の設定形式に対応）

---

## フロントエンド

### `markdown` 設問タイプの追加

- `schema.ts`, `api.ts`, `useQuestionTypeMeta.ts` — 型定義・許可タイプ一覧・エディタメタ情報に `markdown` を追加
- `AnswerQuestionFields.vue` — markdown 設問に `MarkdownEditorField` を使用（回答入力）
- `FormAnswerPreviewPanel.vue` — markdown 設問の回答を `PageMarkdownContent` でレンダリング
- `FormQuestionPreviewItem.vue` — markdown 設問でも `NumberMin`/`NumberMax`（文字数）設定欄を表示；`PreviewMarkdown` を追加
- `previews/PreviewMarkdown.vue` — 新規作成（設問エディタのプレビュー用）
- `forms/[formId]/preview.vue` — markdown 設問に `MarkdownEditorField` を使用
- `schemas.ts` — markdown 設問の必須チェック・文字数バリデーションを追加
- テスト — `AnswerQuestionFields.test.ts`, `FormAnswerPreviewPanel.test.ts`, `schemas.test.ts` にそれぞれケースを追加

### `number` 設問タイプ: 数値自由入力 → ドロップダウン選択

- `AnswerQuestionFields.vue` — `<input type="number">` を `<select>` に変更（`numberMin`〜`numberMax` の整数をリスト表示）
- `forms/[formId]/preview.vue` — 同様の変更
- `previews/PreviewNumber.vue` — 新規作成（ドロップダウン形式のプレビュー）
- `FormQuestionPreviewItem.vue` — number 設問のプレビューに `PreviewNumber` を使用
- E2Eテスト — `requirements.spec.ts` の数値入力を `fill` → `selectOption` に変更

### お問い合わせフォームへの `ccSubleader` フィールド追加

- `contact/api.ts`, `schemas.ts` — `ccSubleader` フィールドを追加（デフォルト `true`）
- `workspace/contact.vue` — 「副責任者にもメールで共有する（CC）」チェックボックスを追加（企画選択時のみ表示）
- テスト — 送信ペイロードに `ccSubleader: true` が含まれることを確認するアサーションを追加

### Markdown 表示エリアの白背景修正

- `FormAnswerPreviewPanel.vue`, `workspace/circles/confirm.vue` — `bg-surface-light`（グレー）→ `bg-surface`（白）
- `PublicPageDetailContent.vue` — Markdownコンテナをカードスタイル（`bg-surface` + `shadow-lv1`）でラップ
- `staff/markdown-guide.vue` — 未定義の `bg-background` → `bg-surface`

---

## テスト計画

- [x] `mise run backend:test` でバックエンドのユニットテストがパスすること
- [x] `mise run frontend:check` でフロントエンドの型チェック・リントがパスすること
- [x] `cd frontend && pnpm test` でフロントエンドのユニットテストがパスすること
- [x] お問い合わせフォームで「副責任者にもメールで共有する」チェックボックスの動作確認
- [x] フォームエディタで `markdown` 設問タイプが追加・プレビューできること
- [x] `number` 設問の回答がドロップダウンで表示されること
- [x] お知らせ詳細ページ（`/public/pages/:pageId`）の背景が白いカードになっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)