### PR TITLE
配布資料におけるdocuments.show のDB依存削減

### DIFF
--- a/app/Eloquents/Document.php
+++ b/app/Eloquents/Document.php
@@ -6,6 +6,7 @@ use App\Eloquents\Concerns\IsNewTrait;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
@@ -14,6 +15,8 @@ class Document extends Model
     use HasFactory;
     use IsNewTrait;
     use LogsActivity;
+
+    public const PUBLIC_CACHE_KEY_PREFIX = 'document.public.';
 
     protected $fillable = [
         'name',
@@ -44,6 +47,11 @@ class Document extends Model
             ->logOnlyDirty();
     }
 
+    public static function publicCacheKey(int $document_id): string
+    {
+        return self::PUBLIC_CACHE_KEY_PREFIX . $document_id;
+    }
+
     /**
      * モデルの「初期起動」メソッド
      *
@@ -55,6 +63,14 @@ class Document extends Model
 
         static::addGlobalScope('updated_at', function (Builder $builder) {
             $builder->latest('updated_at');
+        });
+
+        static::saved(function (Document $document) {
+            Cache::forget(self::publicCacheKey($document->id));
+        });
+
+        static::deleted(function (Document $document) {
+            Cache::forget(self::publicCacheKey($document->id));
         });
     }
 

--- a/app/Http/Controllers/Documents/ShowAction.php
+++ b/app/Http/Controllers/Documents/ShowAction.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Facades\Storage;
 
 class ShowAction extends Controller
 {
+    // documents.id (MySQL INT UNSIGNED) の現実的な最大値
+    private const MAX_DOCUMENT_ID = 4294967295;
+
     public function __invoke(string $document)
     {
         // URLパラメータが数値IDでない場合は不正アクセスとして404にする
@@ -18,29 +21,45 @@ class ShowAction extends Controller
             return;
         }
 
-        $document_id = (int) $document;
+        // 極端に大きいIDは早期に404として扱い、不要な処理を避ける
+        $normalized_document = ltrim($document, '0');
+        if ($normalized_document === '') {
+            $normalized_document = '0';
+        }
+        $max_document_id = (string) self::MAX_DOCUMENT_ID;
+        if (
+            strlen($normalized_document) > strlen($max_document_id) ||
+            (strlen($normalized_document) === strlen($max_document_id) &&
+                strcmp($normalized_document, $max_document_id) > 0)
+        ) {
+            abort(404);
+
+            return;
+        }
+
+        $document_id = (int) $normalized_document;
         $cache_key = Document::publicCacheKey($document_id);
 
-        // 公開済み配布資料の最小情報をキャッシュし、DBアクセス回数を削減する
-        $public_document = Cache::rememberForever($cache_key, function () use ($document_id) {
+        // 公開資料のみを永続キャッシュする（非公開/不存在はキャッシュしない）
+        $public_document = Cache::get($cache_key);
+        if (empty($public_document)) {
             $document = Document::query()
                 ->select(['id', 'path'])
                 ->public()
                 ->find($document_id);
-
-            // 非公開または存在しない資料は「非公開扱い」の結果をキャッシュする
             if (empty($document)) {
-                return ['is_public' => false];
+                abort(404);
+
+                return;
             }
 
-            return [
-                'is_public' => true,
+            $public_document = [
                 'path' => $document->path,
             ];
-        });
+            Cache::forever($cache_key, $public_document);
+        }
 
-        // 公開資料として扱えない場合は詳細を返さず404にする
-        if (! ($public_document['is_public'] ?? false) || empty($public_document['path'])) {
+        if (empty($public_document['path'])) {
             abort(404);
 
             return;

--- a/app/Http/Controllers/Documents/ShowAction.php
+++ b/app/Http/Controllers/Documents/ShowAction.php
@@ -4,18 +4,55 @@ namespace App\Http\Controllers\Documents;
 
 use App\Eloquents\Document;
 use App\Http\Controllers\Controller;
-use Storage;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
 
 class ShowAction extends Controller
 {
-    public function __invoke(Document $document)
+    public function __invoke(string $document)
     {
-        if (! $document->is_public) {
+        // URLパラメータが数値IDでない場合は不正アクセスとして404にする
+        if (! ctype_digit($document)) {
             abort(404);
 
             return;
         }
 
-        return response()->file(Storage::path($document->path));
+        $document_id = (int) $document;
+        $cache_key = Document::publicCacheKey($document_id);
+
+        // 公開済み配布資料の最小情報をキャッシュし、DBアクセス回数を削減する
+        $public_document = Cache::rememberForever($cache_key, function () use ($document_id) {
+            $document = Document::query()
+                ->select(['id', 'path'])
+                ->public()
+                ->find($document_id);
+
+            // 非公開または存在しない資料は「非公開扱い」の結果をキャッシュする
+            if (empty($document)) {
+                return ['is_public' => false];
+            }
+
+            return [
+                'is_public' => true,
+                'path' => $document->path,
+            ];
+        });
+
+        // 公開資料として扱えない場合は詳細を返さず404にする
+        if (! ($public_document['is_public'] ?? false) || empty($public_document['path'])) {
+            abort(404);
+
+            return;
+        }
+
+        // DB上の情報が残っていても実ファイルが無ければ404を返す
+        if (! Storage::exists($public_document['path'])) {
+            abort(404);
+
+            return;
+        }
+
+        return response()->file(Storage::path($public_document['path']));
     }
 }

--- a/tests/Feature/Http/Controllers/Documents/ShowActionTest.php
+++ b/tests/Feature/Http/Controllers/Documents/ShowActionTest.php
@@ -8,6 +8,8 @@ use App\Eloquents\Document;
 use App\Eloquents\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
@@ -23,6 +25,7 @@ final class ShowActionTest extends TestCase
     {
         parent::setUp();
 
+        Cache::flush();
         Storage::fake('local');
 
         // 配布資料
@@ -60,5 +63,84 @@ final class ShowActionTest extends TestCase
             ]));
 
         $response->assertStatus(404);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function 二回目アクセスではdocumentsテーブルを参照しない()
+    {
+        $connection = DB::connection();
+        $connection->enableQueryLog();
+        $connection->flushQueryLog();
+
+        $this->actingAs($this->user)
+            ->get(route('documents.show', [
+                'document' => $this->document,
+            ]))
+            ->assertOk();
+
+        $first_query_log = $connection->getQueryLog();
+        $connection->flushQueryLog();
+
+        $this->actingAs($this->user)
+            ->get(route('documents.show', [
+                'document' => $this->document,
+            ]))
+            ->assertOk();
+
+        $second_query_log = $connection->getQueryLog();
+
+        $this->assertGreaterThan(0, $this->countDocumentsQueries($first_query_log));
+        $this->assertSame(0, $this->countDocumentsQueries($second_query_log));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function 配布資料の実ファイルが存在しない場合は404を返す()
+    {
+        Storage::delete($this->document->path);
+
+        $response = $this->actingAs($this->user)
+            ->get(route('documents.show', [
+                'document' => $this->document,
+            ]));
+
+        $response->assertStatus(404);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function 公開設定の更新時にキャッシュが失効する()
+    {
+        $cache_key = Document::publicCacheKey($this->document->id);
+
+        $this->actingAs($this->user)
+            ->get(route('documents.show', [
+                'document' => $this->document,
+            ]))
+            ->assertOk();
+
+        $this->assertTrue(Cache::has($cache_key));
+
+        $this->document->is_public = false;
+        $this->document->save();
+
+        $this->assertFalse(Cache::has($cache_key));
+
+        $this->actingAs($this->user)
+            ->get(route('documents.show', [
+                'document' => $this->document,
+            ]))
+            ->assertStatus(404);
+    }
+
+    private function countDocumentsQueries(array $query_log): int
+    {
+        return collect($query_log)
+            ->filter(function (array $query) {
+                $sql = strtolower((string) ($query['query'] ?? ''));
+
+                return str_contains($sql, 'from "documents"')
+                    || str_contains($sql, 'from `documents`')
+                    || str_contains($sql, 'from documents');
+            })
+            ->count();
     }
 }

--- a/tests/Feature/Http/Controllers/Documents/ShowActionTest.php
+++ b/tests/Feature/Http/Controllers/Documents/ShowActionTest.php
@@ -66,6 +66,38 @@ final class ShowActionTest extends TestCase
     }
 
     #[\PHPUnit\Framework\Attributes\Test]
+    public function 非公開資料はキャッシュされない()
+    {
+        $this->document->is_public = false;
+        $this->document->save();
+
+        $cache_key = Document::publicCacheKey($this->document->id);
+
+        $this->actingAs($this->user)
+            ->get(route('documents.show', [
+                'document' => $this->document,
+            ]))
+            ->assertStatus(404);
+
+        $this->assertFalse(Cache::has($cache_key));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function 存在しない資料idはキャッシュされない()
+    {
+        $document_id = $this->document->id + 100000;
+        $cache_key = Document::publicCacheKey($document_id);
+
+        $this->actingAs($this->user)
+            ->get(route('documents.show', [
+                'document' => $document_id,
+            ]))
+            ->assertStatus(404);
+
+        $this->assertFalse(Cache::has($cache_key));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
     public function 二回目アクセスではdocumentsテーブルを参照しない()
     {
         $connection = DB::connection();
@@ -91,6 +123,22 @@ final class ShowActionTest extends TestCase
 
         $this->assertGreaterThan(0, $this->countDocumentsQueries($first_query_log));
         $this->assertSame(0, $this->countDocumentsQueries($second_query_log));
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function 上限を超えるidは404を返しdocumentsを参照しない()
+    {
+        $connection = DB::connection();
+        $connection->enableQueryLog();
+        $connection->flushQueryLog();
+
+        $this->actingAs($this->user)
+            ->get(route('documents.show', [
+                'document' => '999999999999999999999999',
+            ]))
+            ->assertStatus(404);
+
+        $this->assertSame(0, $this->countDocumentsQueries($connection->getQueryLog()));
     }
 
     #[\PHPUnit\Framework\Attributes\Test]


### PR DESCRIPTION
## 概要
`/documents/{document}` 表示時のDB負荷を下げるため、`documents.show` の取得経路を改善しました。  
Route Model Binding を使った毎回の `documents` テーブル参照をやめ、公開資料メタ情報をキャッシュ経由で取得するように変更しています。

## 背景
`documents.show` はリクエストごとにDB参照が発生しており、アクセス集中時にDB接続が滞留しやすい状態でした。  
公開資料の参照結果をキャッシュし、更新時に確実に失効させることで負荷を削減します。

## 変更内容
- `Documents\ShowAction` の引数を `Document $document` から `string $document` に変更
- `documents.show` で `Cache::rememberForever` を使用し、公開資料の最小情報（`id`, `path`）をキャッシュ
- キャッシュミス時のみDB参照を実行
- 非公開資料・不正ID・実ファイル欠損時は `404` を返すように統一
- `Document` モデルにキャッシュキー共通化メソッドを追加し、`saved/deleted` 時のキャッシュ破棄キーを統一
- `ShowAction` に処理意図が分かる日本語コメントを追加


## 互換性・影響範囲
- ルートURL・ルート名（`/documents/{document}`, `documents.show`）は変更なし
- 既存の `route('documents.show', ['document' => $document])` 呼び出しはそのまま利用可能

## 確認項目

- [ ] 公開資料はダウンロードできる
- [ ] 非公開資料は `404` になる
- [ ] 実ファイル欠損時は `404` になる
- [ ] 同一資料の2回目アクセス時に `documents` 参照SQLが発生しない（キャッシュヒット）
- [ ] 資料更新後にキャッシュが失効し、更新後状態で判定される
